### PR TITLE
Added support for rufus-scheduler's 'every' syntax to be used optionally instead of the 'cron' syntax.

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -60,13 +60,20 @@ module Resque
           # to.
           if config['rails_env'].nil? || rails_env_matches?(config)
             log! "Scheduling #{name} "
-            if !config['cron'].nil? && config['cron'].length > 0
-              rufus_scheduler.cron config['cron'] do
-                log! "queuing #{config['class']} (#{name})"
-                enqueue_from_config(config)
+            interval_defined = false
+            interval_types = %w{cron every}
+            interval_types.each do |interval_type|
+              if !config[interval_type].nil? && config[interval_type].length > 0
+                rufus_scheduler.send(interval_type, config[interval_type]) do
+                  log! "queueing #{config['class']} (#{name})"
+                  enqueue_from_config(config)
+                end
+                interval_defined = true
+                break
               end
-            else
-              log! "no cron found for #{config['class']} (#{name}) - skipping"
+            end
+            unless interval_defined
+              log! "no #{interval_types.join(' / ')} found for #{config['class']} (#{name}) - skipping"
             end
           end
         end

--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -18,6 +18,8 @@ module ResqueScheduler
   #
   # :name can be anything and is used only to describe the scheduled job
   # :cron can be any cron scheduling string :job can be any resque job class
+  # :every can be used in lieu of :cron. see rufus-scheduler's 'every' usage for 
+  #   valid syntax. If :cron is present it will take precedence over :every.
   # :class must be a resque worker class
   # :args can be any yaml which will be converted to a ruby literal and passed
   #   in a params. (optional)

--- a/lib/resque_scheduler/server/views/scheduler.erb
+++ b/lib/resque_scheduler/server/views/scheduler.erb
@@ -10,7 +10,7 @@
     <th></th>
     <th>Name</th>
     <th>Description</th>
-    <th>Cron</th>
+    <th>Interval</th>
     <th>Class</th>
     <th>Queue</th>
     <th>Arguments</th>
@@ -26,7 +26,9 @@
       </td>
       <td><%= h name %></td>
       <td><%= h config['description'] %></td>
-      <td style="white-space:nowrap"><%= h config['cron'] %></td>
+      <td style="white-space:nowrap"><%= (config['cron'].nil? && !config['every'].nil?) ?
+                                         h('every: ' + config['every']) : 
+                                         h('cron: ' + config['cron']) %></td>
       <td><%= h config['class'] %></td>
       <td><%= h config['queue'] || queue_from_class_name(config['class']) %></td>
       <td><%= h config['args'].inspect %></td>

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -14,7 +14,12 @@ class Resque::SchedulerTest < Test::Unit::TestCase
     Resque::Job.stubs(:create).once.returns(true).with('joes_queue', 'BigJoesJob', '/tmp')
     Resque::Scheduler.enqueue_from_config('cron' => "* * * * *", 'class' => 'BigJoesJob', 'args' => "/tmp", 'queue' => 'joes_queue')
   end
-  
+
+  def test_enqueue_from_config_with_every_syntax
+    Resque::Job.stubs(:create).once.returns(true).with('james_queue', 'JamesJob', '/tmp')
+    Resque::Scheduler.enqueue_from_config('every' => '1m', 'class' => 'JamesJob', 'args' => '/tmp', 'queue' => 'james_queue')
+  end
+
   def test_enqueue_from_config_puts_stuff_in_the_resque_queue
     Resque::Job.stubs(:create).once.returns(true).with(:ivar, 'SomeIvarJob', '/tmp')
     Resque::Scheduler.enqueue_from_config('cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp")


### PR DESCRIPTION
With this commit, each schedule's yaml block can have a 'cron' entry, an 'every' entry, or both. If both are present, 'cron' will win out. 'cron' entries are scheduled via 'scheduler.cron' and 'every' entries are scheduled via 'scheduler.every'. I've done some tests with a mix of both types in the same schedule file and the results look good.

Example new syntax:

chimney_sweep:
  every: "1m"
  custom_job_class: ChimneySweep
  queue: routine_maintenance
  description: Chimney Sweeper

which is equivalent to:

chimney_sweep:
  every: "\* \* \* \* *"
  custom_job_class: ChimneySweep
  queue: routine_maintenance
  description: Chimney Sweeper
