### PR TITLE
Allow specifying the time when scheduling jobs

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -79,10 +79,11 @@ module Resque
       end
 
       # Handles queueing delayed items
-      def handle_delayed_items
-        item = nil
+      # at_time - Time to start scheduling items (default: now).
+      def handle_delayed_items(at_time=nil)
+        timestamp = nil
         begin
-          if timestamp = Resque.next_delayed_timestamp
+          if timestamp = Resque.next_delayed_timestamp(at_time)
             enqueue_delayed_items_for_timestamp(timestamp)
           end
         # continue processing until there are no more ready timestamps

--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -89,8 +89,8 @@ module ResqueScheduler
 
   # Returns the next delayed queue timestamp
   # (don't call directly)
-  def next_delayed_timestamp
-    items = redis.zrangebyscore :delayed_queue_schedule, '-inf', Time.now.to_i, :limit => [0, 1]
+  def next_delayed_timestamp(at_time=nil)
+    items = redis.zrangebyscore :delayed_queue_schedule, '-inf', (at_time || Time.now).to_i, :limit => [0, 1]
     timestamp = items.nil? ? nil : Array(items).first
     timestamp.to_i unless timestamp.nil?
   end


### PR DESCRIPTION
In testing our use of resque-scheduler I often want to verify that jobs are scheduled for the right time in the future. This change allows you to specify a specific time when moving jobs from the schedule to the queue.

```
Resque::Scheduler.handle_delayed_items(Time.now + 600)
```
