### PR TITLE
scheduler erb view: use "custom_job_class" in lieu if "class" if it's available and 'class' is nil

### DIFF
--- a/lib/resque_scheduler/server/views/scheduler.erb
+++ b/lib/resque_scheduler/server/views/scheduler.erb
@@ -29,7 +29,9 @@
       <td style="white-space:nowrap"><%= (config['cron'].nil? && !config['every'].nil?) ?
                                          h('every: ' + config['every']) : 
                                          h('cron: ' + config['cron']) %></td>
-      <td><%= h config['class'] %></td>
+      <td><%= (config['class'].nil? && !config['custom_job_class'].nil?) ?
+              h(config['custom_job_class']) :
+              h(config['class']) %></td>
       <td><%= h config['queue'] || queue_from_class_name(config['class']) %></td>
       <td><%= h config['args'].inspect %></td>
     </tr>


### PR DESCRIPTION
The project I'm currently using resque-scheduler with has all 37 scheduled items set to use a "custom_job_class" in the yaml config block instead of "class". It'd be nice to have these custom class names show up in the scheduler ERB.
