### PR TITLE
Typo fix needed for using 'custom_job_class' with Resque.enqueue_at

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -131,7 +131,7 @@ module Resque
               log "queuing #{item['class']} [delayed]"
               queue = item['queue'] || Resque.queue_from_class(constantize(item['class']))
               # Support custom job classes like job with status
-              if (job_klass = item['custom_job_class']) && (job_klass != 'Resque::Job')
+              if (job_klass = item['args']['custom_job_class']) && (job_klass != 'Resque::Job')
                 # custom job classes not supporting the same API calls must implement the #schedule method
                 constantize(job_klass).scheduled(queue, item['class'], *item['args'])
               else


### PR DESCRIPTION
When a delayed job is enqueued with:

```
Resque.enqueue_at(3.seconds.from_now, MyClass, {'custom_job_class' => 'MyClass', 'foo' => 'bar'})
```

resque-scheduler fails to recognize the enqueued class as a custom job class, because it ends up looking at item['custom_job_class'] instead of item['args']['custom_job_class'] within the enqueue_delayed_items_for_timestamp method.
