### PR TITLE
Exception handling for job enqueue on version 2.0

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -128,14 +128,18 @@ module Resque
         begin
           handle_shutdown do
             if item = Resque.next_item_for_timestamp(timestamp)
-              log "queuing #{item['class']} [delayed]"
-              queue = item['queue'] || Resque.queue_from_class(constantize(item['class']))
-              # Support custom job classes like job with status
-              if (job_klass = item['custom_job_class']) && (job_klass != 'Resque::Job')
-                # custom job classes not supporting the same API calls must implement the #schedule method
-                constantize(job_klass).scheduled(queue, item['class'], *item['args'])
-              else
-                Resque::Job.create(queue, item['class'], *item['args'])
+              begin
+                log "queuing #{item['class']} [delayed]"
+                queue = item['queue'] || Resque.queue_from_class(constantize(item['class']))
+                # Support custom job classes like job with status
+                if (job_klass = item['custom_job_class']) && (job_klass != 'Resque::Job')
+                  # custom job classes not supporting the same API calls must implement the #schedule method
+                  constantize(job_klass).scheduled(queue, item['class'], *item['args'])
+                else
+                  Resque::Job.create(queue, item['class'], *item['args'])
+                end
+              rescue
+                log! "Failed to enqueue #{klass_name}:\n #{$!}"
               end
             end
           end
@@ -169,6 +173,8 @@ module Resque
         else
           Resque::Job.create(queue, klass_name, *params)
         end        
+      rescue
+        log! "Failed to enqueue #{klass_name}:\n #{$!}"
       end
 
       def rufus_scheduler

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -25,6 +25,11 @@ class Resque::SchedulerTest < Test::Unit::TestCase
     Resque::Scheduler.enqueue_from_config('every' => '1m', 'class' => 'JamesJob', 'args' => '/tmp', 'queue' => 'james_queue')
   end
 
+  def test_enqueue_from_config_doesnt_crash_on_exception_when_enqueueing
+    Resque::Job.stubs(:create).raises(Resque::NoQueueError, 'test exception').with(:ivar, 'SomeIvarJob', '/tmp')
+    Resque::Scheduler.enqueue_from_config('cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp")
+  end
+
   def test_enqueue_from_config_puts_stuff_in_the_resque_queue
     Resque::Job.stubs(:create).once.returns(true).with(:ivar, 'SomeIvarJob', '/tmp')
     Resque::Scheduler.enqueue_from_config('cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp")


### PR DESCRIPTION
Same as previous request, but built on master.

I think this is a worthwhile patch to backport to 1.9.  Changing the redis version requirement is a big deal for users with a large production redis deployment.
