### PR TITLE
    Validate job class before delayed enqueue. 

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -85,6 +85,7 @@ module ResqueScheduler
   # for queueing.  Until timestamp is in the past, the job will
   # sit in the schedule list.
   def enqueue_at(timestamp, klass, *args)
+    validate_job!(klass)
     delayed_push(timestamp, job_to_hash(klass, args))
   end
 
@@ -191,6 +192,16 @@ module ResqueScheduler
       if 0 == redis.llen(key).to_i
         redis.del key
         redis.zrem :delayed_queue_schedule, timestamp.to_i
+      end
+    end
+
+    def validate_job!(klass)
+      if klass.to_s.empty?
+        raise Resque::NoClassError.new("Jobs must be given a class.")
+      end
+
+      unless queue_from_class(klass)
+        raise Resque::NoQueueError.new("Jobs must be placed onto a queue.")
       end
     end
 

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -217,4 +217,13 @@ class Resque::DelayedQueueTest < Test::Unit::TestCase
     assert_equal(2, Resque.remove_delayed(SomeIvarJob, "bar"))
     assert_equal(2, Resque.count_all_scheduled_jobs)
   end
+
+  def test_invalid_job_class
+    assert_raise Resque::NoClassError do
+      Resque.enqueue_in(10, nil)
+    end
+    assert_raise Resque::NoQueueError do
+      Resque.enqueue_in(10, String) # string serves as invalid Job class
+    end
+  end
 end


### PR DESCRIPTION
```
Resque does check of the job class before enqueue it.
Resque-scheduler doesn't do that before put them into the schedule.
That is why we see error no on schedule but at execution.
This is not correct. We should do same checks as redis do:
https://github.com/defunkt/resque/blob/master/lib/resque/job.rb#L39

Unfortunatelly we can not reuse code.
```

I beleive we should do the same same staff before in set _.set_schedule_ method. 
But I am not sure that the job class in the schedule is always defined in the context on this method.
