### PR TITLE
Display timezone in scheduler timestamp

### DIFF
--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -10,7 +10,7 @@ module ResqueScheduler
 
         helpers do
           def format_time(t)
-            t.strftime("%Y-%m-%d %H:%M:%S")
+            t.strftime("%Y-%m-%d %H:%M:%S %z")
           end
 
           def queue_from_class_name(class_name)


### PR DESCRIPTION
When dev, customer and server placed in different timezones it's hard to figure out and always remember what timezone is used in Scheduler pages on the Resque web.

That's why i think it's a good idea to always show a timezone.
