### PR TITLE
Saves pid to pid file

### DIFF
--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -1,4 +1,4 @@
-# require 'resque/tasks'
+require 'resque/tasks'
 # will give you the resque tasks
 
 namespace :resque do
@@ -8,6 +8,8 @@ namespace :resque do
   task :scheduler => :scheduler_setup do
     require 'resque'
     require 'resque_scheduler'
+
+    File.open(ENV['PIDFILE'], 'w') { |f| f << Process.pid.to_s } if ENV['PIDFILE']
 
     Resque::Scheduler.verbose = true if ENV['VERBOSE']
     Resque::Scheduler.run


### PR DESCRIPTION
Hi
Just added the code to save the scheduler pid to the PIDFILE environment variable. This is exactly same as resque.

This means that i can now consistently kill  resque-scheduler via

kill -9 `cat foo.pid`

assuming PIDFILE=foo.pid

Cheers
Sreekanth
