### PR TITLE
Support for hooks with resque >= 1.15.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,19 +1,14 @@
 PATH
   remote: .
   specs:
-    resque-scheduler (1.9.7)
+    resque-scheduler (2.0.0.c)
       redis (>= 2.0.1)
-      resque (>= 1.8.0)
+      resque (>= 1.15.0)
       rufus-scheduler
 
 GEM
   remote: http://rubygems.org/
   specs:
-    git (1.2.5)
-    jeweler (1.5.1)
-      bundler (~> 1.0.0)
-      git (>= 1.2.5)
-      rake
     json (1.4.6)
     mocha (0.9.9)
       rake
@@ -21,21 +16,21 @@ GEM
     rack-test (0.5.6)
       rack (>= 1.0)
     rake (0.8.7)
-    redis (2.1.1)
-    redis-namespace (0.8.0)
+    redis (2.2.0)
+    redis-namespace (0.10.0)
       redis (< 3.0.0)
-    resque (1.10.0)
+    resque (1.15.0)
       json (~> 1.4.6)
-      redis-namespace (~> 0.8.0)
+      redis-namespace (>= 0.10.0)
       sinatra (>= 0.9.2)
       vegas (~> 0.1.2)
-    rufus-scheduler (2.0.7)
-      tzinfo
-    sinatra (1.1.0)
+    rufus-scheduler (2.0.8)
+      tzinfo (>= 0.3.23)
+    sinatra (1.2.1)
       rack (~> 1.1)
-      tilt (~> 1.1)
-    tilt (1.1)
-    tzinfo (0.3.23)
+      tilt (< 2.0, >= 1.2.2)
+    tilt (1.2.2)
+    tzinfo (0.3.25)
     vegas (0.1.8)
       rack (>= 1.0.0)
 
@@ -43,10 +38,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  jeweler
+  bundler (>= 1.0.0)
   mocha
   rack-test
-  redis (>= 2.0.1)
-  resque (>= 1.8.0)
   resque-scheduler!
-  rufus-scheduler

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_runtime_dependency(%q<redis>, [">= 2.0.1"])
-  s.add_runtime_dependency(%q<resque>, [">= 1.8.0"])
+  s.add_runtime_dependency(%q<resque>, [">= 1.15.0"])
   s.add_runtime_dependency(%q<rufus-scheduler>, [">= 0"])
   s.add_development_dependency(%q<mocha>, [">= 0"])
   s.add_development_dependency(%q<rack-test>, [">= 0"])

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -126,8 +126,7 @@ class Resque::DelayedQueueTest < Test::Unit::TestCase
     Resque.enqueue_at(t, SomeIvarJob)
 
     # 2 SomeIvarJob jobs should be created in the "ivar" queue
-    Resque::Job.expects(:create).twice.with('ivar', 'SomeIvarJob', nil)
-    Resque.expects(:queue_from_class).never # Should NOT need to load the class
+    Resque::Job.expects(:create).twice.with(:ivar, SomeIvarJob, nil)
     Resque::Scheduler.handle_delayed_items
   end
 
@@ -137,8 +136,7 @@ class Resque::DelayedQueueTest < Test::Unit::TestCase
     Resque.enqueue_at(t, SomeIvarJob)
 
     # 2 SomeIvarJob jobs should be created in the "ivar" queue
-    Resque::Job.expects(:create).twice.with('ivar', 'SomeIvarJob', nil)
-    Resque.expects(:queue_from_class).never # Should NOT need to load the class
+    Resque::Job.expects(:create).twice.with(:ivar, SomeIvarJob, nil)
     Resque::Scheduler.handle_delayed_items(t)
   end
 
@@ -149,8 +147,7 @@ class Resque::DelayedQueueTest < Test::Unit::TestCase
     Resque.enqueue_at(t, SomeIvarJob)
 
     # 2 SomeIvarJob jobs should be created in the "ivar" queue
-    Resque::Job.expects(:create).twice.with('ivar', 'SomeIvarJob', nil)
-    Resque.expects(:queue_from_class).never # Should NOT need to load the class
+    Resque::Job.expects(:create).twice.with(:ivar, SomeIvarJob, nil)
 
     Resque::Scheduler.enqueue_delayed_items_for_timestamp(t)
 
@@ -165,7 +162,7 @@ class Resque::DelayedQueueTest < Test::Unit::TestCase
     # Since we didn't specify :queue when calling delayed_push, it will be forced
     # to load the class to figure out the queue.  This is the upgrade case from 1.0.4
     # to 1.0.5.
-    Resque::Job.expects(:create).once.with(:ivar, 'SomeIvarJob', nil)
+    Resque::Job.expects(:create).once.with(:ivar, SomeIvarJob, nil)
 
     Resque::Scheduler.handle_delayed_items
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -76,3 +76,9 @@ end
 class SomeIvarJob < SomeJob
   @queue = :ivar
 end
+
+class SomeRealClass
+  def self.queue
+    :some_real_queue
+  end
+end


### PR DESCRIPTION
Fixes scheduler to fire hooks when jobs are finally queued.
