### PR TITLE
Some dynamic fixes

### DIFF
--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -11,6 +11,7 @@ namespace :resque do
 
     File.open(ENV['PIDFILE'], 'w') { |f| f << Process.pid.to_s } if ENV['PIDFILE']
 
+    Resque::Scheduler.dynamic = true if ENV['DYNAMIC_SCHEDULE']
     Resque::Scheduler.verbose = true if ENV['VERBOSE']
     Resque::Scheduler.run
   end


### PR DESCRIPTION
environment doesn't have to be loaded to have the scheduler be dynamic.

Some other fixes:
- Allow USR1 to print out the rufus scheduler for debugging
- Load the schedules during load (this may have been fixed in another
  commit)
