### PR TITLE
Show dynamically-added schedules in resque-web.

### DIFF
--- a/lib/resque_scheduler/server/views/scheduler.erb
+++ b/lib/resque_scheduler/server/views/scheduler.erb
@@ -15,8 +15,9 @@
     <th>Queue</th>
     <th>Arguments</th>
   </tr>
-  <% Resque.schedule.keys.sort.each do |name| %>
-    <% config = Resque.schedule[name] %>
+  <% @schedule = Resque.get_schedules %>
+  <% @schedule.keys.sort.each do |name| %>
+    <% config = @schedule[name] %>
     <tr>
       <td>
         <form action="<%= u "/schedule/requeue" %>" method="post">


### PR DESCRIPTION
Dynamically-added events weren't being properly shown in resque-web. This patches the 'scheduler.erb' view to load them dynamically on page-load when '/schedule' is loaded.
