### PR TITLE
Add a "Clear Delayed Jobs" button to the Delayed Jobs page

### DIFF
--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -45,6 +45,11 @@ module ResqueScheduler
           Resque::Scheduler.enqueue_delayed_items_for_timestamp(timestamp.to_i) if timestamp.to_i > 0
           redirect u("/overview")
         end
+        
+        post "/delayed/clear" do
+          Resque.reset_delayed_queue
+          redirect u('delayed')
+        end
 
       end
 

--- a/lib/resque_scheduler/server/views/delayed.erb
+++ b/lib/resque_scheduler/server/views/delayed.erb
@@ -1,11 +1,17 @@
 <h1>Delayed Jobs</h1>
+<%- size = resque.delayed_queue_schedule_size %>
+<% if size > 0 %>
+  <form method="POST" action="<%=u 'delayed/clear'%>" class='clear-delayed'>
+    <input type='submit' name='' value='Clear Delayed Jobs' />
+  </form>
+<% end %>
 
 <p class='intro'>
   This list below contains the timestamps for scheduled delayed jobs.
 </p>
 
 <p class='sub'>
-  Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of <b><%=size = resque.delayed_queue_schedule_size %></b> timestamps
+  Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of <b><%= size %></b> timestamps
 </p>
 
 <table>


### PR DESCRIPTION
Done in a similar way to the Clear Failed Jobs button in Resque proper. The button only shows up if there are delayed jobs queued up.
