### PR TITLE
Enable running resque-scheduler as a daemon.

### DIFF
--- a/lib/generators/resque_scheduler_generator.rb
+++ b/lib/generators/resque_scheduler_generator.rb
@@ -1,0 +1,10 @@
+class ResqueSchedulerGenerator < Rails::Generators::Base
+
+  source_root File.expand_path("../templates", __FILE__)
+
+  def create_resque_scheduler_file
+    template 'resque-scheduler', 'script/resque-scheduler'
+    chmod 'script/resque-scheduler', 0755
+  end
+
+end

--- a/lib/generators/templates/resque-scheduler
+++ b/lib/generators/templates/resque-scheduler
@@ -1,0 +1,22 @@
+#!/usr/bin/env ruby
+
+require 'rubygems'
+require 'bundler/setup'
+require 'resque'
+require 'resque_scheduler'
+
+# Daemons sets pwd to /, so we have to explicitly set RAILS_ROOT
+RAILS_ROOT = File.expand_path(File.join(File.dirname(__FILE__), '..'))
+
+rails_env = ENV['RAILS_ENV'] || 'development'
+
+resque_config = if File.exist?("#{RAILS_ROOT}/config/resque.yml")
+    YAML.load_file("#{RAILS_ROOT}/config/resque.yml")[rails_env]
+  else
+    "127.0.0.1:6379"
+  end
+
+Resque.redis = resque_config
+Resque.redis.namespace = "resque:#{rails_env}"
+
+Resque::SchedulerDaemon.new(ARGV).daemonize

--- a/lib/resque/scheduler_daemon.rb
+++ b/lib/resque/scheduler_daemon.rb
@@ -1,0 +1,59 @@
+require 'rubygems'
+require 'daemons'
+require 'optparse'
+require 'logger'
+
+module Resque
+  # A wrapper designed to daemonize a Resque::Scheduler instance to keep in
+  # running in the background.
+  # Connects output to a custom logger, if available. Creates a pid file
+  # suitable for monitoring with {monit}[http://mmonit.com/monit/].
+  #
+  # To use in a Rails app, <code>script/rails generate resque_scheduler</code>.
+  class SchedulerDaemon
+
+    def initialize(args)
+      @options = {:environment => :development, :delay => 5}
+
+      optparse = OptionParser.new do |opts|
+        opts.banner = "Usage: #{File.basename($0)} [options] start|stop|restart|run"
+
+        opts.on('-h', '--help', 'Show this message.') do
+          puts opts
+          exit 1
+        end
+        opts.on('-e', '--environment=NAME', 'Specifies the environment to run this resque-scheduler in ([development]/production).') do |e|
+          @options[:environment] = e
+        end
+        opts.on('-v', '--verbose', "Turn on verbose mode.") do
+          @options[:verbose] = true
+        end
+        opts.on('-q', '--quiet', "Turn off logging.") do
+          @options[:quiet] = true
+        end
+        opts.on('-d', '--delay=D', "Delay between rounds of work (seconds).") do |d|
+          @options[:delay] = d.to_i
+        end
+      end
+
+      # If no arguments, give help screen
+      @args = optparse.parse!(args.empty? ? ['-h'] : args)
+    end
+
+    def daemonize
+      Daemons.run_proc("resque-scheduler", :dir => "#{::RAILS_ROOT}/tmp/pids", :dir_mode => :normal, :ARGV=> @args) do
+        logger = Logger.new(File.join(::RAILS_ROOT, 'log', 'resque-scheduler.log'))
+        Resque::Scheduler.logger = logger
+        Resque::Scheduler.delay = @options[:delay]
+        Resque::Scheduler.verbose = @options[:verbose]
+        Resque::Scheduler.run
+      end
+    rescue => e
+      STDERR.puts e.message
+      logger.fatal(e) if logger && logger.respond_to?(:fatal)
+      exit 1
+    end
+
+  end
+
+end

--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -1,9 +1,10 @@
 require 'rubygems'
 require 'resque'
 require 'resque/server'
-require 'resque_scheduler/version'
 require 'resque/scheduler'
+require 'resque/scheduler_daemon'
 require 'resque_scheduler/server'
+require 'resque_scheduler/version'
 
 module ResqueScheduler
 
@@ -16,7 +17,7 @@ module ResqueScheduler
   #                  "description" => "this thing works it"s butter off"},
   #    ...}
   #
-  # 'some_name' can be anything and is used only to describe and reference 
+  # 'some_name' can be anything and is used only to describe and reference
   # the scheduled job
   #
   # :cron can be any cron scheduling string :job can be any resque job class
@@ -48,12 +49,12 @@ module ResqueScheduler
   def schedule
     @schedule ||= {}
   end
-  
+
   # reloads the schedule from redis
   def reload_schedule!
     @schedule = get_schedules
   end
-  
+
   # gets the schedule as it exists in redis
   def get_schedules
     if redis.exists(:schedules)
@@ -66,12 +67,12 @@ module ResqueScheduler
       nil
     end
   end
-  
+
   # Create or update a schedule with the provided name and configuration.
   #
   # Note: values for class and custom_job_class need to be strings,
   # not constants.
-  #  
+  #
   #    Resque.set_schedule('some_job', {:class => 'SomeJob',
   #                                     :every => '15mins',
   #                                     :queue => 'high',
@@ -84,12 +85,12 @@ module ResqueScheduler
     end
     config
   end
-  
+
   # retrive the schedule configuration for the given name
   def get_schedule(name)
     decode(redis.hget(:schedules, name))
   end
-  
+
   # remove a given schedule by name
   def remove_schedule(name)
     redis.hdel(:schedules, name)
@@ -106,7 +107,7 @@ module ResqueScheduler
   end
 
   # Identical to +enqueue_at+, except you can also specify
-  # a queue in which the job will be placed after the 
+  # a queue in which the job will be placed after the
   # timestamp has passed.
   def enqueue_at_with_queue(queue, timestamp, klass, *args)
     delayed_push(timestamp, job_to_hash_with_queue(queue, klass, args))
@@ -119,7 +120,7 @@ module ResqueScheduler
   end
 
   # Identical to +enqueue_in+, except you can also specify
-  # a queue in which the job will be placed after the 
+  # a queue in which the job will be placed after the
   # number of seconds has passed.
   def enqueue_in_with_queue(queue, number_of_seconds_from_now, klass, *args)
     enqueue_at_with_queue(queue, Time.now + number_of_seconds_from_now, klass, *args)
@@ -205,19 +206,19 @@ module ResqueScheduler
   end
 
   def count_all_scheduled_jobs
-    total_jobs = 0 
+    total_jobs = 0
     Array(redis.zrange(:delayed_queue_schedule, 0, -1)).each do |timestamp|
       total_jobs += redis.llen("delayed:#{timestamp}").to_i
-    end 
+    end
     total_jobs
-  end 
+  end
 
   private
-  
+
     def job_to_hash(klass, args)
       {:class => klass.to_s, :args => args, :queue => queue_from_class(klass)}
     end
-    
+
     def job_to_hash_with_queue(queue, klass, args)
       {:class => klass.to_s, :args => args, :queue => queue}
     end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency(%q<redis>, [">= 2.0.1"])
   s.add_runtime_dependency(%q<resque>, [">= 1.15.0"])
   s.add_runtime_dependency(%q<rufus-scheduler>, [">= 0"])
+  s.add_runtime_dependency(%q<daemons>, [">= 1.1.0"])
   s.add_development_dependency(%q<mocha>, [">= 0"])
   s.add_development_dependency(%q<rack-test>, [">= 0"])
 end


### PR DESCRIPTION
I didn't like the fact that resque-scheduler could only be executed as a rake task. The rake task loads the Rails environment, even though that is not necessary at all.

However, the bigger problem I had was that there was no reasonable way to run resque-scheduler as a daemon (with start/stop/restart script, pidfile, proper logging, etc.) without building your own custom solution (i.e., shell script).

This pull request addresses those problems. In order to run resque-scheduler as a daemon, generate `script/resque-scheduler` by invoking `script/rails generate resque_scheduler` . Then, `script/resque-scheduler --help` will output a list of the available options.
