### PR TITLE
Support ENV['BACKGROUND'] flag for daemonizing

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -265,6 +265,16 @@ Now make sure you're passing that file to resque-web like so:
 
 That should make the scheduler tabs show up in `resque-web`.
 
+### Running in the background
+
+(Only supported with ruby >= 1.9). There are scenarios where it's helpful for
+the resque worker to run itself in the background (usually in combination with
+PIDFILE).  Use the BACKGROUND option so that rake will return as soon as the
+worker is started.
+
+    $ PIDFILE=./resque-scheduler.pid BACKGROUND=yes \
+        rake resque:scheduler
+
 ### Plagiarism alert
 
 This was intended to be an extension to resque and so resulted in a lot of the

--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -9,6 +9,13 @@ namespace :resque do
     require 'resque'
     require 'resque_scheduler'
 
+    if ENV['BACKGROUND']
+      unless Process.respond_to?('daemon')
+        abort "env var BACKGROUND is set, which requires ruby >= 1.9"
+      end
+      Process.daemon(true)
+    end
+
     File.open(ENV['PIDFILE'], 'w') { |f| f << Process.pid.to_s } if ENV['PIDFILE']
 
     Resque::Scheduler.dynamic = true if ENV['DYNAMIC_SCHEDULE']


### PR DESCRIPTION
This brings feature parity with the latest (HEAD) version of resque when
running a daemonized worker (see:
https://github.com/defunkt/resque/commit/8d92f032fc4ee0c05c928c17ecdbf7f72196816d).
