### PR TITLE
Separate queuing library from the server

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -1,9 +1,7 @@
 require 'rubygems'
 require 'resque'
-require 'resque/server'
 require 'resque_scheduler/version'
 require 'resque/scheduler'
-require 'resque_scheduler/server'
 
 module ResqueScheduler
 
@@ -275,6 +273,3 @@ module ResqueScheduler
 end
 
 Resque.extend ResqueScheduler
-Resque::Server.class_eval do
-  include ResqueScheduler::Server
-end

--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -1,3 +1,5 @@
+require 'resque_scheduler'
+require 'resque/server'
 
 # Extend Resque::Server to add tabs
 module ResqueScheduler
@@ -60,4 +62,8 @@ module ResqueScheduler
 
   end
   
+end
+
+Resque::Server.class_eval do
+  include ResqueScheduler::Server
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -8,9 +8,9 @@ require 'rubygems'
 require 'test/unit'
 require 'mocha'
 require 'resque'
-require File.join(dir, '../lib/resque_scheduler')
 $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
-
+require 'resque_scheduler'
+require 'resque_scheduler/server'
 
 #
 # make sure we can run redis


### PR DESCRIPTION
I'm using this library to delay processing of items in my Rails app.  Unfortunately, when I require 'resque_scheduler', it loads 'resque/server' and transitively 'sinatra/base'.  Sinatra ends up interfering with Rails via rack.

This change is to separate the data-access library that can be used from anywhere (resque_scheduler) and the admin UI server (resque_scheduler/server).  This follows the Resque convention of keeping the library (resque) separate from the server (resque/server)
