### PR TITLE
Support for Resque::JobWithStatus being queued via #enqueue_at and friends

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -239,11 +239,19 @@ module ResqueScheduler
   private
   
     def job_to_hash(klass, args)
-      {:class => klass.to_s, :args => args, :queue => queue_from_class(klass)}
+      base_job_hash(klass).merge(:args => args, :queue => queue_from_class(klass))
     end
     
     def job_to_hash_with_queue(queue, klass, args)
-      {:class => klass.to_s, :args => args, :queue => queue}
+      base_job_hash(klass).merge(:args => args, :queue => queue)
+    end
+
+    def base_job_hash(klass)
+      {:class => klass.to_s}.tap do |hash|
+        if klass.instance_variable_get(:@require_custom_class)
+          hash.merge! :custom_job_class => klass.to_s
+        end
+      end
     end
 
     def clean_up_timestamp(key, timestamp)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -69,6 +69,8 @@ def context(*args, &block)
 end
 
 class FakeCustomJobClass
+  @require_custom_class = true
+
   def self.scheduled(queue, klass, *args); end
 end
 


### PR DESCRIPTION
Queuing Resque::JobWithStatus jobs fail, as they fall back to the normal Resque::Job.create behavior when they are scheduled.  This is because the job_hash doesn't include the :custom_job_class parameter that the config file has support for.

This change allows the jobs to set an instance variable (which isn't the best way but works) that indicates they require the custom_job_class parameter.
