### PR TITLE
SIGTERM took too long to shutdown

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -1,5 +1,4 @@
 require 'rufus/scheduler'
-require 'thwait'
 
 module Resque
 


### PR DESCRIPTION
If ran on slow machine (e.g. small VPS) and resque-scheduler is managed by daemon manager (e.g. Supervisord),

during restart (e.g. _/etc/init.d/supervisord restart_),

_run()_ responded to SIGTERM but took too long to shutdown, resulting in multiple processes running.

This commit will exit the loop immediately when _@shutdown == true_. I think it is safe to do it this way since all the scheduled jobs themselves are documented inside _scheduled_jobs.yml_.

Sys-admins or deployers can simply make sure they don't deploy during the time described in _scheduled_jobs.yml_

This behavior is similar to resque where it simply perform _exit()_ and kill all children without mercy.
