### PR TITLE
Use job name as implicit class name in the schedule

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -158,10 +158,15 @@ The schedule is a list of Resque worker classes with arguments and a
 schedule frequency (in crontab syntax).  The schedule is just a hash, but
 is most likely stored in a YAML like so:
 
+    CancelAbandonedOrders:
+      cron: "*/5 * * * *"
+
     queue_documents_for_indexing:
       cron: "0 0 * * *"
       # you can use rufus-scheduler "every" syntax in place of cron if you prefer
       # every: 1hr
+      # By default the job name (hash key) will be taken as worker class name.
+      # If you want to have a different job name and class name, provide the 'class' option
       class: QueueDocuments
       queue: high
       args: 

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -165,6 +165,24 @@ context "Resque::Scheduler" do
       Resque.decode(Resque.redis.hget(:schedules, "my_ivar_job")))
   end
 
+  test "schedule= uses job name as 'class' argument if it's missing" do
+    Resque::Scheduler.dynamic = true
+    Resque.schedule = {"SomeIvarJob" => {
+      'cron' => "* * * * *", 'args' => "/tmp/75"
+    }}
+    assert_equal({'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp/75"},
+      Resque.decode(Resque.redis.hget(:schedules, "SomeIvarJob")))
+    assert_equal('SomeIvarJob', Resque.schedule['SomeIvarJob']['class'])
+  end
+
+  test "schedule= does not mutate argument" do
+    schedule = {"SomeIvarJob" => {
+      'cron' => "* * * * *", 'args' => "/tmp/75"
+    }}
+    Resque.schedule = schedule
+    assert !schedule['SomeIvarJob'].key?('class')
+  end
+
   test "set_schedule can set an individual schedule" do
     Resque.set_schedule("some_ivar_job", {
       'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp/22"


### PR DESCRIPTION
When configuring the schedule, the only required argument is 'class'.
On the other hand, the job name (hash key) is not too useful and usually
just duplicates the resque worker class name (underscored).

So instead of having to do:

```
some_job:
  class: SomeJob
  cron: '* * * * *'
another_job:
  class: AnotherJob
  every: 1m
job_name_different_than_class:
  class: WeirdlyNamedClass
```

You can now do:

```
SomeJob:
  cron: '* * * * *'
AnotherJob:
  every: 1m
job_name_different_than_class:
  class: WeirdlyNamedClass
```

By default, the job name will be treated as class name,
but you can still provide a different job name and class name.
