### PR TITLE
Fix hooks support for Ruby 1.8.7

### DIFF
--- a/lib/resque_scheduler/plugin.rb
+++ b/lib/resque_scheduler/plugin.rb
@@ -14,7 +14,7 @@ module ResqueScheduler
     end
 
     def method_missing(method_name, *args, &block)
-      if method_name =~ /^run_(.*)_hooks$/
+      if method_name.to_s =~ /^run_(.*)_hooks$/
         job = args.shift
         run_hooks job, $1, *args
       else


### PR DESCRIPTION
Hooks work for 1.9.x, but not for Ruby 1.8.7. Relates to issue #148.

Please see discussion here: https://github.com/andreas/resque-scheduler/commit/b10a06aa6e753652bab897c4c068b8835440b003.
