### PR TITLE
Make Resque.schedule= set, not append

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -25,6 +25,9 @@ module ResqueScheduler
   # is used implicitly as "class" argument - in the "MakeTea" example,
   # "MakeTea" is used both as job name and resque worker class.
   #
+  # Any jobs that were in the old schedule, but are not 
+  # present in the new schedule, will be removed.
+  #
   # :cron can be any cron scheduling string
   #
   # :every can be used in lieu of :cron. see rufus-scheduler's 'every' usage
@@ -46,8 +49,12 @@ module ResqueScheduler
     schedule_hash = prepare_schedule(schedule_hash)
 
     if Resque::Scheduler.dynamic
+      reload_schedule!
       schedule_hash.each do |name, job_spec|
         set_schedule(name, job_spec)
+      end
+      (schedule.keys - schedule_hash.keys.map(&:to_s)).each do |name|
+        remove_schedule(name)
       end
     end
     @schedule = schedule_hash

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -192,6 +192,17 @@ context "Resque::Scheduler" do
     assert_equal({'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp/75"},
       Resque.decode(Resque.redis.hget(:schedules, "my_ivar_job")))
   end
+  
+  test "schedule= removes schedules not present in the given schedule argument" do
+    Resque::Scheduler.dynamic = true
+
+    Resque.schedule = {"old_job" => {'cron' => "* * * * *", 'class' => 'OldJob'}}
+    assert_equal({"old_job" => {'cron' => "* * * * *", 'class' => 'OldJob'}}, Resque.schedule)
+
+    Resque.schedule = {"new_job" => {'cron' => "* * * * *", 'class' => 'NewJob'}}
+    Resque.reload_schedule!
+    assert_equal({"new_job" => {'cron' => "* * * * *", 'class' => 'NewJob'}}, Resque.schedule)
+  end
 
   test "schedule= uses job name as 'class' argument if it's missing" do
     Resque::Scheduler.dynamic = true


### PR DESCRIPTION
Ensures that any jobs that were previously added to the schedule, but that have since been removed from the config, will be removed from the schedule when the new config is passed to `Resque.schedule=`.
