### PR TITLE
Keep BACKGROUND from automatically redirecting stderr/stdout to /dev/null

### DIFF
--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -9,11 +9,14 @@ namespace :resque do
     require 'resque'
     require 'resque_scheduler'
 
+    # Need to set this here for conditional Process.daemon redirect of stderr/stdout to /dev/null
+    Resque::Scheduler.mute = true if ENV['MUTE'] 
+
     if ENV['BACKGROUND']
       unless Process.respond_to?('daemon')
         abort "env var BACKGROUND is set, which requires ruby >= 1.9"
       end
-      Process.daemon(true)
+      Process.daemon(true,!Resque::Scheduler.mute)
     end
 
     File.open(ENV['PIDFILE'], 'w') { |f| f << Process.pid.to_s } if ENV['PIDFILE']


### PR DESCRIPTION
Ruby 1.9's Process.daemon redirects stderr/stdout to /dev/null which makes logging impossible. This change prevents Process.daemon from redirecting stderr and stout to /dev/null unless ENV['MUTE'] is set.
