### PR TITLE
Fix scheduler template when array is passed to rufus-scheduler

### DIFF
--- a/lib/resque_scheduler/server/views/scheduler.erb
+++ b/lib/resque_scheduler/server/views/scheduler.erb
@@ -27,9 +27,9 @@
       <td><%= h name %></td>
       <td><%= h config['description'] %></td>
       <td style="white-space:nowrap"><%= if !config['every'].nil? 
-                                           h('every: ' + config['every'])
+                                           h('every: ' + config['every'].to_s)
                                          elsif !config['cron'].nil?
-                                           h('cron: ' + config['cron']) 
+                                           h('cron: ' + config['cron'].to_s) 
                                          else
                                            'Not currently scheduled'
                                          end %></td>

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -13,7 +13,7 @@ context "on GET to /schedule with scheduled jobs" do
   setup do 
     ENV['rails_env'] = 'production'
     Resque.schedule = {:some_ivar_job => {'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp", 'rails_env' => 'production'},
-                       :some_other_job => {'queue' => 'high', 'class' => 'SomeOtherJob', 'args' => {:b => 'blah'}}}
+                       :some_other_job => {'every' => ['5m'], 'queue' => 'high', 'class' => 'SomeOtherJob', 'args' => {:b => 'blah'}}}
     Resque::Scheduler.load_schedule!
     get "/schedule"
   end


### PR DESCRIPTION
When passing array to rufus-scheduler, like so:

``` yaml
test_job:
  every:
  - 5m
  - :first_in: 30s
  class: TestJob
  queue: test_job
  description: 'Test job run will run at 5 minute intervals, with a 30 second startup delay'
```

The scheduler template in the web UI would choke with "Can't convert array to string".
