### PR TITLE
Fix for 500 error in resque-web when using custom job classes

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -282,6 +282,9 @@ module ResqueScheduler
       prepared_hash = {}
       schedule_hash.each do |name, job_spec|
         job_spec = job_spec.dup
+        if job_spec.key?('custom_job_class') && !job_spec.key?('class')
+          job_spec['class'] = job_spec['custom_job_class']
+        end
         job_spec['class'] = name unless job_spec.key?('class') || job_spec.key?(:class)
         prepared_hash[name] = job_spec
       end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -203,6 +203,16 @@ context "Resque::Scheduler" do
     assert_equal('SomeIvarJob', Resque.schedule['SomeIvarJob']['class'])
   end
 
+  test "schedule= uses the custom job name as 'class' argument if 'class' is missing" do
+    Resque::Scheduler.dynamic = true
+    Resque.schedule = {"SomeIvarJob" => {
+      'cron' => "* * * * *", 'custom_job_class' => 'FakeCustomJobClass', 'args' => "/tmp/75"
+    }}
+    assert_equal({'cron' => "* * * * *", 'custom_job_class' => 'FakeCustomJobClass', 'class' => 'FakeCustomJobClass', 'args' => "/tmp/75"},
+      Resque.decode(Resque.redis.hget(:schedules, "SomeIvarJob")))
+    assert_equal('FakeCustomJobClass', Resque.schedule['SomeIvarJob']['class'])
+  end
+
   test "schedule= does not mutate argument" do
     schedule = {"SomeIvarJob" => {
       'cron' => "* * * * *", 'args' => "/tmp/75"


### PR DESCRIPTION
Resque-web did not check the "custom_job_class" for its queue, and instead attempted to check the "class" in the configuration, which is incorrect for jobs that use a custom job class.
