### PR TITLE
Better fix for "queue" name issue with custom_job_classes

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -282,6 +282,9 @@ module ResqueScheduler
       prepared_hash = {}
       schedule_hash.each do |name, job_spec|
         job_spec = job_spec.dup
+        if job_spec.key?('custom_job_class') && !job_spec.key?('class')
+          job_spec['class'] = job_spec['custom_job_class']
+        end
         job_spec['class'] = name unless job_spec.key?('class') || job_spec.key?(:class)
         prepared_hash[name] = job_spec
       end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -203,6 +203,16 @@ context "Resque::Scheduler" do
     assert_equal('SomeIvarJob', Resque.schedule['SomeIvarJob']['class'])
   end
 
+  test "schedule= uses the custom job name as 'class' argument if 'class' is missing" do
+    Resque::Scheduler.dynamic = true
+    Resque.schedule = {"SomeIvarJob" => {
+      'cron' => "* * * * *", 'custom_job_class' => 'FakeCustomJobClass', 'args' => "/tmp/75"
+    }}
+    assert_equal({'cron' => "* * * * *", 'custom_job_class' => 'FakeCustomJobClass', 'class' => 'FakeCustomJobClass', 'args' => "/tmp/75"},
+      Resque.decode(Resque.redis.hget(:schedules, "SomeIvarJob")))
+    assert_equal('FakeCustomJobClass', Resque.schedule['SomeIvarJob']['class'])
+  end
+
   test "schedule= does not mutate argument" do
     schedule = {"SomeIvarJob" => {
       'cron' => "* * * * *", 'args' => "/tmp/75"


### PR DESCRIPTION
Note that this fix supersedes the fix I proposed in Issue #170.

Since much of the resque-scheduler code expects the job "class" to be set to something reasonable, I made sure that "class" it is set to the "custom_job_class" if the "class" was not explicitly defined. Some of this behavior in ragards to custom_job_class and class is very confusing, but I'll leave that for another issue.

For more detail about the exact issue that I'm attempting to address, see below:

In the scenario where:
- the job spec defines a "custom_job_class"
- the job spec does not define a "class" (my expectation is that it shouldn't have to if it's specified a custom one)
- the job spec does not define a "queue" (since the custom_job_class does)

A proper queue would not be determined for the custom job class, which caused:
- the schedule tab in resque-web to raise a 500 error
- jobs to be enqueued to "false" instead of the queue defined in the custom job class
