### PR TITLE
Show server local time in scheduler tabs of resque-web

### DIFF
--- a/lib/resque_scheduler/server/views/delayed.erb
+++ b/lib/resque_scheduler/server/views/delayed.erb
@@ -8,6 +8,7 @@
 
 <p class='intro'>
   This list below contains the timestamps for scheduled delayed jobs.
+  Server local time: <%= Time.now %>
 </p>
 
 <p class='sub'>

--- a/lib/resque_scheduler/server/views/scheduler.erb
+++ b/lib/resque_scheduler/server/views/scheduler.erb
@@ -3,6 +3,7 @@
 <p class='intro'>
   The list below contains all scheduled jobs.  Click &quot;Queue now&quot; to queue
   a job immediately.
+  Server local time: <%= Time.now %>
 </p>
 
 <table>


### PR DESCRIPTION
Showing server time might be useful to know exactly when the task gonna be queued.
