### PR TITLE
Use Resque.validate instead of custom .validate_job!

### DIFF
--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -110,7 +110,7 @@ module ResqueScheduler
   # for queueing.  Until timestamp is in the past, the job will
   # sit in the schedule list.
   def enqueue_at(timestamp, klass, *args)
-    validate_job!(klass)
+    validate(klass)
     enqueue_at_with_queue(queue_from_class(klass), timestamp, klass, *args)
   end
 
@@ -266,15 +266,6 @@ module ResqueScheduler
         end
       else
         redis.unwatch
-      end
-    end
-    def validate_job!(klass)
-      if klass.to_s.empty?
-        raise Resque::NoClassError.new("Jobs must be given a class.")
-      end
-
-      unless queue_from_class(klass)
-        raise Resque::NoQueueError.new("Jobs must be placed onto a queue.")
       end
     end
 

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -304,9 +304,6 @@ context "DelayedQueue" do
   end
 
   test "invalid job class" do
-    assert_raise Resque::NoClassError do
-      Resque.enqueue_in(10, nil)
-    end
     assert_raise Resque::NoQueueError do
       Resque.enqueue_in(10, String) # string serves as invalid Job class
     end


### PR DESCRIPTION
Job class validation is now a part of resque API.
No need for custom method anymore.

It has slightly different behavior. That is why there is a need to change test. But it still fits problem we are trying to solve.
