### PR TITLE
Fix rails_env option in schedules

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -9,6 +9,8 @@ module Resque
 
     class << self
 
+      ENV['RAILS_ENV'] = Rails.env if defined?(Rails.env)
+
       # If true, logs more stuff...
       attr_accessor :verbose
 
@@ -122,9 +124,8 @@ module Resque
       # Loads a job schedule into the Rufus::Scheduler and stores it in @@scheduled_jobs
       def load_schedule_job(name, config)
         # If rails_env is set in the config, enforce ENV['RAILS_ENV'] as
-        # required for the jobs to be scheduled.  If rails_env is missing, the
-        # job should be scheduled regardless of what ENV['RAILS_ENV'] is set
-        # to.
+        # required for the jobs to be scheduled. If rails_env is missing, the
+        # job should be scheduled regardless of what ENV['RAILS_ENV'] is set to
         if config['rails_env'].nil? || rails_env_matches?(config)
           log! "Scheduling #{name} "
           interval_defined = false

--- a/test/redis-test.conf
+++ b/test/redis-test.conf
@@ -112,4 +112,4 @@ databases 16
 # Glue small output buffers together in order to send small replies in a
 # single TCP packet. Uses a bit more CPU but most of the times it is a win
 # in terms of number of queries per second. Use 'yes' if unsure.
-glueoutputbuf yes
+# glueoutputbuf yes

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,7 +6,7 @@ dir = File.dirname(File.expand_path(__FILE__))
 
 require 'rubygems'
 require 'test/unit'
-require 'mocha'
+require 'mocha/setup'
 require 'resque'
 $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
 require 'resque_scheduler'


### PR DESCRIPTION
As ENV['RAILS_ENV'] has been deprecated in Rails 3
and remove in Rails 3.1. I have left ENV['RAILS_ENV'] for backward
compatibility
