### PR TITLE
Fix Gemfile to use 'https://rubygems.org'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 gemspec
 
 group :test do


### PR DESCRIPTION
Just a quick fix to get rid of the following deprecation warning with bundler 1.3:

```
The source :rubygems is deprecated because HTTP requests are insecure.
Please change your source to 'https://rubygems.org' if possible, or 'http://rubygems.org' if not.
```
