### PR TITLE
Add process tagging for scheduler process

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -20,6 +20,9 @@ module Resque
       # If set, will try to update the schedule in the loop
       attr_accessor :dynamic
 
+      # If set, will append the app name to procline
+      attr_accessor :app_name
+
       # Amount of time in seconds to sleep between polls of the delayed
       # queue.  Defaults to 5
       attr_writer :poll_sleep_amount
@@ -311,9 +314,13 @@ module Resque
         log!(msg) if verbose
       end
 
+      def app_str
+        app_name ? "[#{app_name}]" : ''
+      end
+
       def procline(string)
         log! string
-        $0 = "resque-scheduler-#{ResqueScheduler::VERSION}: #{string}"
+        $0 = "resque-scheduler-#{ResqueScheduler::VERSION}#{app_str}: #{string}"
       end
 
     end

--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -23,6 +23,7 @@ namespace :resque do
 
     Resque::Scheduler.dynamic = true if ENV['DYNAMIC_SCHEDULE']
     Resque::Scheduler.verbose = true if ENV['VERBOSE']
+    Resque::Scheduler.app_name = ENV['APP_NAME'] if ENV['APP_NAME']
     Resque::Scheduler.run
   end
 


### PR DESCRIPTION
On a server hosting multiple apps requiring multiple instances of
resque-scheduler, it can be difficult to tell which scheduler proc
goes with which app. This change adds an APP_NAME environment
variable that, if set, appends the app name to the procline.

Eg.:
`resque-scheduler-2.0.0.h[my-app-name]: Schedules Loaded`
