### PR TITLE
Add environment name to procline

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -11,6 +11,9 @@ module Resque
 
     class << self
 
+      # environment
+      attr_accessor :env
+
       # If true, logs more stuff...
       attr_accessor :verbose
 
@@ -313,7 +316,11 @@ module Resque
 
       def procline(string)
         log! string
-        $0 = "resque-scheduler-#{ResqueScheduler::VERSION}: #{string}"
+        if env
+          $0 = "resque-scheduler-#{ResqueScheduler::VERSION} [#{env}]: #{string}"
+        else
+          $0 = "resque-scheduler-#{ResqueScheduler::VERSION}: #{string}"
+        end
       end
 
     end


### PR DESCRIPTION
leave the possibility to configure it by user's own rake setup task 

``` ruby
Resque::Scheduler.env = Rails.env
```
