### PR TITLE
Redis namespace

### DIFF
--- a/lib/resque/scheduler_locking.rb
+++ b/lib/resque/scheduler_locking.rb
@@ -80,7 +80,7 @@ module Resque
     end
 
     def master_lock_key
-      :resque_scheduler_master_lock
+      "#{Resque.redis.namespace}:resque_scheduler_master_lock"
     end
 
     def redis_master_version


### PR DESCRIPTION
Resque scheduler should follow settings of redis namespace in resque. If you have more applications with schedulers running and using same redis database, you end up with only one application scheduler running.
