### PR TITLE
added description in README doc for rake task to load with environment

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -104,6 +104,9 @@ never exits.
 
     $ rake resque:scheduler
 
+or
+
+    $ rake environment resque:scheduler ## If you want to load environment 
 Supported environment variables are `VERBOSE` and `MUTE`.  If either is set to
 any nonempty value, they will take effect.  `VERBOSE` simply dumps more output
 to stdout.  `MUTE` does the opposite and silences all output. `MUTE`


### PR DESCRIPTION
Added description in README doc for rake task to load with environment.

Well Personally I have do this because my `Resque` was using a **different** Redis connection other then the default _redis://127.0.0.1:6379_ for which I had to defined my Redis connection for Resque in initializer file like this 

``` ruby
  #config/initializer/resque_connection.rb
  Resque.redis = Redis.new( )
```

Now this **work well** with Resque and the Redis connection is picked up correctly but when **resque_scheduler**  rake task is invoked the my Redis connection is not taken into consideration and the rake tasks  dies/fail saying "Connection Timeout" which is correct  because `resque_scheduler` rake task does not load the environment **so in use case like this** it is important to load the **rake task along with environment** something like this 

``` ruby
rake environment resque_scheduler
```

And I don't see this documented any where hence doing the same
