### PR TITLE
Fixing schedule in a test to only have string keys

### DIFF
--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -12,8 +12,8 @@ end
 context "on GET to /schedule with scheduled jobs" do
   setup do 
     ENV['rails_env'] = 'production'
-    Resque.schedule = {:some_ivar_job => {'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp", 'rails_env' => 'production'},
-                       :some_other_job => {'every' => ['5m'], 'queue' => 'high', 'class' => 'SomeOtherJob', 'args' => {:b => 'blah'}}}
+    Resque.schedule = {'some_ivar_job' => {'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp", 'rails_env' => 'production'},
+                       'some_other_job' => {'every' => ['5m'], 'queue' => 'high', 'class' => 'SomeOtherJob', 'args' => {'b' => 'blah'}}}
     Resque::Scheduler.load_schedule!
     get "/schedule"
   end


### PR DESCRIPTION
which is always the case for data retrieved from redis (for now).

This was the source of some seemingly flaky test failures.  Hopefully fixed now.
