### PR TITLE
Shutdown gracefully in ruby 2.0.0.

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -312,7 +312,7 @@ module Resque
       def shutdown
         @shutdown = true
         if @sleeping
-          release_master_lock!
+          Thread.new { release_master_lock! }
           exit
         end
       end


### PR DESCRIPTION
Fixes issue #228.

Avoid `ThreadError: can't be called from trap context` on shutdown.

Using mutexes inside traps is deadlockable and prohibited in ruby 2.0.
Instead, do the work in a seperate thread.

See discussion at https://bugs.ruby-lang.org/issues/7917
