### PR TITLE
Remove dependency on Resque::Helpers

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -6,7 +6,6 @@ module Resque
 
   class Scheduler
 
-    extend Resque::Helpers
     extend Resque::SchedulerLocking
 
     class << self
@@ -220,7 +219,7 @@ module Resque
         args = job_config['args'] || job_config[:args]
 
         klass_name = job_config['class'] || job_config[:class]
-        klass = constantize(klass_name) rescue klass_name
+        klass = Resque.constantize(klass_name) rescue klass_name
 
         params = args.is_a?(Hash) ? [args] : Array(args)
         queue = job_config['queue'] || job_config[:queue] || Resque.queue_from_class(klass)
@@ -230,7 +229,7 @@ module Resque
           # job class can not be constantized (via a requeue call from the web perhaps), fall
           # back to enqueing normally via Resque::Job.create.
           begin
-            constantize(job_klass).scheduled(queue, klass_name, *params)
+            Resque.constantize(job_klass).scheduled(queue, klass_name, *params)
           rescue NameError
             # Note that the custom job class (job_config['custom_job_class']) is the one enqueued
             Resque::Job.create(queue, job_klass, *params)


### PR DESCRIPTION
`Resque::Helpers` will be gone with no replacement in Resque 2.0.0. This pull request removes `resque-scheduler`'s dependency on `Resque::Helpers`
