### PR TITLE
Locking rufus-scheduler dependency to ~> 2.0

### DIFF
--- a/lib/resque_scheduler/version.rb
+++ b/lib/resque_scheduler/version.rb
@@ -1,3 +1,3 @@
 module ResqueScheduler
-  VERSION = '2.1.0'
+  VERSION = '2.1.1'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -28,5 +28,5 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'redis', '>= 3.0.0'
   spec.add_runtime_dependency 'resque', ['>= 1.20.0', '< 1.25']
-  spec.add_runtime_dependency 'rufus-scheduler', '>= 0'
+  spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
 end


### PR DESCRIPTION
as referenced in #264, which I'm planning to leave open until this dependency can be bumped to `~> 3.0`.
