### PR TITLE
Add rufus scheduler `every` notice to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ clear_leaderboards_moderator:
   description: "This job will check Daemon every 30 seconds after 120 seconds after start"
 ```
 
+IMPORTANT: Rufus `every` syntax will calculate jobs scheduling time starting from the moment of deploy,
+resulting in resetting schedule time on every deploy, so it's probably a good idea to use it only for
+frequent jobs (like every 10-30 minutes), otherwise - when you use something like `every 20h` and deploy once-twice per day -
+it will schedule the job for 20 hours from deploy, resulting in a job to never be run.
+
 NOTE: Six parameter cron's are also supported (as they supported by
 rufus-scheduler which powers the resque-scheduler process).  This allows you
 to schedule jobs per second (ie: `"30 * * * * *"` would fire a job every 30


### PR DESCRIPTION
Currently, when you set up a job using `every` syntax - it starts calculating the schedule time from the moment of deploy. So, in case you want to set up a task with schedule time being `every 30h`, and you redeploy your application in 15 hours from that moment - it will start calculating from zero again. If you deploy once-twice per day, and set tasks like, say, `every 20h` - it will be rarely getting run, if run at all.
Unfortunately, it's not stated in the README.md.
This commit adds it to readme so that new users don't get into this trouble cause this feature is a bit unobvious.
