### PR TITLE
upgraded dependence of resque to support 1.25

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -51,6 +51,7 @@ Resque Scheduler authors
 - Spring MC
 - Tim Liner
 - Tony Lewis
+- Vincent Zhu
 - V Sreekanth
 - andreas
 - bbauer

--- a/Gemfile
+++ b/Gemfile
@@ -2,4 +2,4 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'yajl-ruby', '~> 0.8.2', :platforms => :mri, :group => :test
+gem 'yajl-ruby', '>= 1.1.0', :platforms => :mri, :group => :test

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -220,7 +220,7 @@ module Resque
         args = job_config['args'] || job_config[:args]
 
         klass_name = job_config['class'] || job_config[:class]
-        klass = Resque.constantize(klass_name) rescue klass_name
+        klass = ResqueScheduler::Util.constantize(klass_name) rescue klass_name
 
         params = args.is_a?(Hash) ? [args] : Array(args)
         queue = job_config['queue'] || job_config[:queue] || Resque.queue_from_class(klass)
@@ -230,7 +230,7 @@ module Resque
           # job class can not be constantized (via a requeue call from the web perhaps), fall
           # back to enqueing normally via Resque::Job.create.
           begin
-            Resque.constantize(job_klass).scheduled(queue, klass_name, *params)
+            ResqueScheduler::Util.constantize(job_klass).scheduled(queue, klass_name, *params)
           rescue NameError
             # Note that the custom job class (job_config['custom_job_class']) is the one enqueued
             Resque::Job.create(queue, job_klass, *params)

--- a/lib/resque_scheduler.rb
+++ b/lib/resque_scheduler.rb
@@ -1,6 +1,7 @@
 require 'rubygems'
 require 'resque'
 require 'resque_scheduler/version'
+require 'resque_scheduler/util'
 require 'resque/scheduler'
 require 'resque_scheduler/plugin'
 

--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -1,6 +1,5 @@
 require 'resque_scheduler'
 require 'resque/server'
-
 # Extend Resque::Server to add tabs
 module ResqueScheduler
 
@@ -16,7 +15,7 @@ module ResqueScheduler
           end
 
           def queue_from_class_name(class_name)
-            Resque.queue_from_class(Resque.constantize(class_name))
+            Resque.queue_from_class(ResqueScheduler::Util.constantize(class_name))
           end
         end
 

--- a/lib/resque_scheduler/util.rb
+++ b/lib/resque_scheduler/util.rb
@@ -1,0 +1,34 @@
+module ResqueScheduler
+  class Util
+    # In order to upgrade to resque(1.25) which has deprecated following methods ,
+    # we just added these usefull helpers back to use in Resque Scheduler.
+    # refer to: https://github.com/resque/resque-scheduler/pull/273
+    
+    def self.constantize(camel_cased_word)
+      camel_cased_word = camel_cased_word.to_s
+
+      if camel_cased_word.include?('-')
+        camel_cased_word = classify(camel_cased_word)
+      end
+
+      names = camel_cased_word.split('::')
+      names.shift if names.empty? || names.first.empty?
+
+      constant = Object
+      names.each do |name|
+        args = Module.method(:const_get).arity != 1 ? [false] : []
+
+        if constant.const_defined?(name, *args)
+          constant = constant.const_get(name)
+        else
+          constant = constant.const_missing(name)
+        end
+      end
+      constant
+    end
+
+    def self.classify(dashed_word)
+      dashed_word.split('-').each { |part| part[0] = part[0].chr.upcase }.join
+    end
+  end
+end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop' unless RUBY_VERSION < '1.9'
 
   spec.add_runtime_dependency 'redis', '>= 3.0.0'
-  spec.add_runtime_dependency 'resque', ['>= 1.20.0', '< 1.25']
+  spec.add_runtime_dependency 'resque', ['>= 1.20.0', '> 1.25']
   spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
 end


### PR DESCRIPTION
1. the 1.25 version removed 'require resque/helper' , so the "Resque.constantize(klass_name)" don't work anymore. I fixed this by adding our own helper methods.
2. why we don't upgrade 'yajl-ruby' to 1.1.0 ? (0.8.2 got problem with Mountain Lion.)
3. All tests passed on ruby 2.0 .
4. Thanks. 
