### PR TITLE
Use Float() instead of Integer() to calculate poll sleep amount

### DIFF
--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -25,7 +25,7 @@ namespace :resque do
     Resque::Scheduler.dynamic           = true if ENV['DYNAMIC_SCHEDULE']
     Resque::Scheduler.verbose           = true if ENV['VERBOSE']
     Resque::Scheduler.logfile           = ENV['LOGFILE'] if ENV['LOGFILE']
-    Resque::Scheduler.poll_sleep_amount = Integer(ENV['INTERVAL']) if ENV['INTERVAL']
+    Resque::Scheduler.poll_sleep_amount = Float(ENV['INTERVAL']) if ENV['INTERVAL']
     Resque::Scheduler.run
   end
 


### PR DESCRIPTION
I realize the README states using an integer value here but seeing as this poll interval is only sent to `sleep()`, restricting this doesn't really have any benefit and limits precision. Using `Float()` instead will allow both floats and integers to function correctly.
