### PR TITLE
Touching up some specs, hopefully to eliminate random failures on ree

### DIFF
--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -28,6 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop' unless RUBY_VERSION < '1.9'
 
   spec.add_runtime_dependency 'redis', '>= 3.0.0'
-  spec.add_runtime_dependency 'resque', ['>= 1.20.0', '> 1.25']
+  spec.add_runtime_dependency 'resque', '~> 1.25'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
 end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -12,8 +12,22 @@ end
 context "on GET to /schedule with scheduled jobs" do
   setup do
     ENV['rails_env'] = 'production'
-    Resque.schedule = {'some_ivar_job' => {'cron' => "* * * * *", 'class' => 'SomeIvarJob', 'args' => "/tmp", 'rails_env' => 'production'},
-                       'some_other_job' => {'every' => ['5m'], 'queue' => 'high', 'class' => 'SomeOtherJob', 'args' => {'b' => 'blah'}}}
+    Resque.schedule = {
+      'some_ivar_job' => {
+        'cron' => "* * * * *",
+        'class' => 'SomeIvarJob',
+        'args' => "/tmp",
+        'rails_env' => 'production'
+      },
+      'some_other_job' => {
+        'every' => ['5m'],
+        'queue' => 'high',
+        'class' => 'SomeOtherJob',
+        'args' => {
+          'b' => 'blah'
+        }
+      }
+    }
     Resque::Scheduler.load_schedule!
     get "/schedule"
   end
@@ -34,14 +48,18 @@ end
 def resque_schedule
   {
     'job_without_params' => {
-      'cron' => "* * * * *",
+      'cron' => '* * * * *',
       'class' => 'JobWithoutParams',
-      'args' => {"host" => 'localhost'},
+      'args' => {
+        'host' => 'localhost'
+      },
       'rails_env' => 'production'},
     'job_with_params' => {
-      'cron' => "* * * * *",
+      'cron' => '* * * * *',
       'class' => 'JobWithParams',
-      'args' => {"host" => 'localhost'},
+      'args' => {
+        'host' => 'localhost'
+      },
       'parameters' => {
         'log_level' => {
           'description' => 'The level of logging',

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -84,6 +84,14 @@ class SomeRealClass
   end
 end
 
+class JobWithParams
+  def self.perform(*args)
+    @args = args
+  end
+end
+
+JobWithoutParams = Class.new(JobWithParams)
+
 def nullify_logger
   Resque::Scheduler.mute    = nil
   Resque::Scheduler.verbose = nil


### PR DESCRIPTION
plus switching to runtime dependency of `resque ~> 1.25` so that we don't accidentally break folks who upgrade to `resque >= 2`.
