### PR TITLE
Added RESQUE_SCHEDULER_INTERVAL in place of INTERVAL

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,10 +416,15 @@ Resque::Scheduler.logfile = nil # that means, all messages go to STDOUT
 
 ### Polling frequency
 
-You can pass an INTERVAL option which is a integer representing the polling frequency.
-The default is 5 seconds, but for a semi-active app you may want to use a smaller (integer) value.
+You can pass a `RESQUE_SCHEDULER_INTERVAL` option which is an integer or float
+representing the polling frequency. The default is 5 seconds, but for a
+semi-active app you may want to use a smaller value.
 
-    $ INTERVAL=1 rake resque:scheduler
+    $ RESQUE_SCHEDULER_INTERVAL=1 rake resque:scheduler
+
+**NOTE** This value was previously `INTERVAL` but was renamed to
+`RESQUE_SCHEDULER_INTERVAL` to avoid clashing with the interval Resque
+uses for its jobs.
 
 ### Plagiarism alert
 

--- a/lib/resque_scheduler/tasks.rb
+++ b/lib/resque_scheduler/tasks.rb
@@ -25,7 +25,7 @@ namespace :resque do
     Resque::Scheduler.dynamic           = true if ENV['DYNAMIC_SCHEDULE']
     Resque::Scheduler.verbose           = true if ENV['VERBOSE']
     Resque::Scheduler.logfile           = ENV['LOGFILE'] if ENV['LOGFILE']
-    Resque::Scheduler.poll_sleep_amount = Float(ENV['INTERVAL']) if ENV['INTERVAL']
+    Resque::Scheduler.poll_sleep_amount = Float(ENV['RESQUE_SCHEDULER_INTERVAL']) if ENV['RESQUE_SCHEDULER_INTERVAL']
     Resque::Scheduler.run
   end
 


### PR DESCRIPTION
This will avoid clashes between the resque-scheduler poll interval
and the one resque uses for workers
