### PR TITLE
Fix re-introduced ThreadError on Ruby 2

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -313,8 +313,11 @@ module Resque
         @shutdown = true
 
         if @sleeping
-          Resque.clean_schedules
-          Thread.new { release_master_lock! }
+          thread = Thread.new do
+            Resque.clean_schedules
+            release_master_lock!
+          end
+          thread.join
           exit
         end
       end


### PR DESCRIPTION
See #228.

The previous solution didn't actually wait for the thread to finish, so
it might have exited before the thread had finished its work. So I've
added a #join too.
