### PR TITLE
Correcting the gemspec to use the right `require_paths`

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+## 2.3.1 (2013-11-20)
+
+* Correcting `require_paths` in gemspec
+
 ## 2.3.0 (2013-11-07)
 
 * Fix re-introduced `ThreadError` on Ruby 2

--- a/lib/resque_scheduler/version.rb
+++ b/lib/resque_scheduler/version.rb
@@ -1,3 +1,5 @@
+# vim:fileencoding=utf-8
+
 module ResqueScheduler
-  VERSION = '2.3.0'
+  VERSION = '2.3.1'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -1,4 +1,4 @@
-# -*- encoding: utf-8 -*-
+# vim:fileencoding=utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require 'resque_scheduler/version'
@@ -15,10 +15,10 @@ Gem::Specification.new do |spec|
     Also supports queueing jobs on a fixed, cron-like schedule.}
   spec.license = 'MIT'
 
-  spec.files        = `git ls-files`.split("\n")
-  spec.executables  = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
-  spec.test_files   = spec.files.grep(%r{^test/})
-  spec.require_path = ['lib']
+  spec.files         = `git ls-files`.split("\n")
+  spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
+  spec.test_files    = spec.files.grep(%r{^test/})
+  spec.require_paths = ['lib']
 
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'mocha'


### PR DESCRIPTION
khanify singular vs. plural

Closes #287
