### PR TITLE
Fix unsafe Resque::Scheduler shutdown in Ruby 2.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,4 +6,5 @@ group :test do
   gem "rack-test"
   gem "yajl-ruby", "~>0.8.2", :platforms => :mri
   gem "mocha"
+  gem "debugger"
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
   s.require_path = 'lib'
 
   s.add_runtime_dependency(%q<redis>, [">= 2.0.1"])
-  s.add_runtime_dependency(%q<resque>, [">= 1.20.0"])
-  s.add_runtime_dependency(%q<rufus-scheduler>, [">= 0"])
+  s.add_runtime_dependency(%q<resque>, [">= 1.20.0", "< 1.25"])
+  s.add_runtime_dependency(%q<rufus-scheduler>, ["~> 2.0"])
 end

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -1,0 +1,34 @@
+require File.dirname(__FILE__) + '/test_helper'
+
+context "Resque::Scheduler" do
+  setup do
+    Resque::Scheduler.dynamic = false
+    Resque.redis.flushall
+    Resque::Scheduler.mute = true
+    Resque::Scheduler.clear_schedule!
+    Resque::Scheduler.send(:class_variable_set, :@@scheduled_jobs, {})
+  end
+
+  test "shutdown raises Interrupt when sleeping" do
+    Thread.current.expects(:raise).with(Interrupt)
+    Resque::Scheduler.send(:instance_variable_set, :@th, Thread.current)
+    Resque::Scheduler.send(:instance_variable_set, :@sleeping, true)
+    Resque::Scheduler.shutdown
+  end
+
+  test "sending TERM to scheduler breaks out of poll_sleep" do
+    Resque::Scheduler.expects(:release_master_lock!)
+    fork do
+      sleep(0.5)
+      system("kill -TERM #{Process.ppid}")
+      exit!
+    end
+
+    assert_raises SystemExit do
+      Resque::Scheduler.run
+    end
+
+    Resque::Scheduler.unstub(:release_master_lock!)
+    Resque::Scheduler.release_master_lock!
+  end
+end


### PR DESCRIPTION
@camilo, @Sirupsen /cc: @fbogsany

This makes shutdown compatible with Ruby 2.0 by not calling
release_master_locks! in the Resque::Scheduler signal handler.
