### PR TITLE
Using `require_relative 'test_helper'` everywhere

### DIFF
--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -1,4 +1,4 @@
-require 'test_helper'
+require_relative 'test_helper'
 
 context 'Cli' do
   def new_cli(argv = [], env = {})

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context "DelayedQueue" do
 

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 # Pull in the server test_helper from resque
 require 'resque/server/test_helper.rb'

--- a/test/scheduler_args_test.rb
+++ b/test/scheduler_args_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context "scheduling jobs with arguments" do
 

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context "scheduling jobs with hooks" do
   setup do

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 module LockTestHelper
   def lock_is_not_held(lock)

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context "Resque::Scheduler" do
   setup do

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context "Resque::Scheduler" do
   setup do

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -1,4 +1,4 @@
-require File.dirname(__FILE__) + '/test_helper'
+require_relative 'test_helper'
 
 context 'Resque::Scheduler' do
   setup do


### PR DESCRIPTION
because the $LOAD_PATH addition wasn't working consistently (weird!) and we don't care about ree anymore (yay!)
