### PR TITLE
Fix confusion with version requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ that adds support for queueing items in the future.
 
 This table explains the version requirements for redis
 
-| resque-scheduler version | required redis version|
+| resque-scheduler version | required redis gem version|
 |:-------------------------|----------------------:|
 | ~> 2.0                   | >= 3.0.0              |
 | >= 0.0.1                 | ~> 1.3                |


### PR DESCRIPTION
I was very confused for a while about the requirement of redis version >= 3.0.0 (There is no Redis 3.0.0) until I finally realized it meant the redis gem!
