### PR TITLE
Use logger.error when logging errors from handle_errors

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -25,6 +25,7 @@ Resque Scheduler authors
 - Harry Lascelles
 - Henrik Nyh
 - James Le Cuirot
+- Jarkko Mönkkönen
 - John Crepezzi
 - John Griffin
 - Jon Larkowski and Les Hill

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -276,7 +276,7 @@ module Resque
         begin
           yield
         rescue Exception => e
-          log! "#{e.class.name}: #{e.message}"
+          log_error "#{e.class.name}: #{e.message}"
         end
       end
 
@@ -396,6 +396,10 @@ module Resque
 
       def log!(msg)
         logger.info { msg }
+      end
+
+      def log_error(msg)
+        logger.error { msg }
       end
 
       def log(msg)


### PR DESCRIPTION
Log errors as errors to get the [ERROR] tag to log lines with error.

This is needed if you are using some log reader or analysing the logs based on tags. Otherwise errors are not showing up from the [INFO] messages.

It is also nice to see the error lines easier if you are manually checking/grepping the logs.
