### PR TITLE
Making dependency versions more specific for 2.5 stable

### DIFF
--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop' unless RUBY_VERSION < '1.9'
   spec.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
 
-  spec.add_runtime_dependency 'redis', '>= 3.0.0'
-  spec.add_runtime_dependency 'resque', '~> 1.25'
-  spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0'
+  spec.add_runtime_dependency 'redis', '~> 3.0.4'
+  spec.add_runtime_dependency 'resque', '~> 1.25.1'
+  spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0.24'
 end


### PR DESCRIPTION
although I fully admit that I don't understand how the `~>` operator works.
