### PR TITLE
Backporting signal handling while "sleeping" from #352

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,7 @@ CaseEquality:
   Enabled: false
 
 ClassLength:
-  Max: 318
+  Max: 325
 
 ClassVars:
   Enabled: false

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -105,25 +105,8 @@ context 'Cli' do
     cli.pre_run
   end
 
-  test 'initializes dynamic from the env' do
-    cli = new_cli([], { 'DYNAMIC_SCHEDULE' => '1' })
-    assert_equal('flurb', cli.send(:options)[:dynamic])
-  end
-
   test 'defaults to nil dynamic' do
     assert_equal(nil, new_cli.send(:options)[:dynamic])
-  end
-
-  test 'accepts dynamic via -D' do
-    cli = new_cli(%w(-D))
-    cli.parse_options
-    assert_equal(true, cli.send(:options)[:dynamic])
-  end
-
-  test 'accepts dynamic via --dynamic-schedule' do
-    cli = new_cli(%w(--dynamic-schedule))
-    cli.parse_options
-    assert_equal(true, cli.send(:options)[:dynamic])
   end
 
   test 'initializes env from the env' do


### PR DESCRIPTION
plus removing those duplicate tests I meant to clean up in `v2.5-stable`
