### PR TITLE
Ensuring lock #timeout= behavior is consistent based on locked state

### DIFF
--- a/lib/resque/scheduler/lock/resilient.rb
+++ b/lib/resque/scheduler/lock/resilient.rb
@@ -20,6 +20,10 @@ module Resque
           ).to_i == 1
         end
 
+        def timeout=(t)
+          @timeout = t if locked?
+        end
+
         private
 
         def locked_sha(refresh = false)

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -238,5 +238,25 @@ context 'Resque::Scheduler::Lock::Resilient' do
 
       assert Resque.redis.ttl(@lock.key) <= 10, "TTL should not have been updated"
     end
+
+    test 'setting the lock timeout changes the key TTL if we hold it' do
+      @lock.acquire!
+
+      @lock.timeout = 120
+      ttl = Resque.redis.ttl(@lock.key)
+      assert_send [ttl, :>, 100]
+
+      @lock.timeout = 180
+      ttl = Resque.redis.ttl(@lock.key)
+      assert_send [ttl, :>, 120]
+    end
+
+    test 'setting the lock timeout is a noop if not held' do
+      @lock.acquire!
+      @lock.timeout = 100
+      @lock.stubs(:locked?).returns(false)
+      @lock.timeout = 120
+      assert_equal 100, @lock.timeout
+    end
   end
 end


### PR DESCRIPTION
Closes #299
