### PR TITLE
Testing against same rubies as resque (+ 2.1.0)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,16 @@ language: ruby
 rvm:
 - 1.9.3
 - 2.0.0
+- 2.1.0
+- jruby-19mode
+- rbx
 env:
   global:
   - RESQUE_SCHEDULER_DISABLE_TEST_REDIS_SERVER=1
+matrix:
+  allow_failures:
+  - rvm: jruby-19mode
+  - rvm: rbx
 services:
 - redis-server
 notifications:


### PR DESCRIPTION
as well as allowing failures for the same rubies.
