### PR TITLE
Switch to using mono_logger instead of stdlib logger

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,9 +145,9 @@ scheduled job must run (coerced with `Kernel#Float()`) (default `5`)
 default `'text'`)
 * `PIDFILE` - If non-empty, write process PID to file (default empty)
 * `QUIET` or `MUTE` - Silence most output if non-empty (equivalent to
-a level of `Logger::FATAL`, default `false`)
+a level of `MonoLogger::FATAL`, default `false`)
 * `VERBOSE` - Maximize log verbosity if non-empty (equivalent to a level
-of `Logger::DEBUG`, default `false`)
+of `MonoLogger::DEBUG`, default `false`)
 
 
 ### Resque Pool integration 

--- a/lib/resque_scheduler/logger_builder.rb
+++ b/lib/resque_scheduler/logger_builder.rb
@@ -1,5 +1,7 @@
 # vim:fileencoding=utf-8
 
+require 'mono_logger'
+
 module ResqueScheduler
   # Just builds a logger, with specified verbosity and destination.
   # The simplest example:
@@ -26,9 +28,9 @@ module ResqueScheduler
       @format = opts[:format] || 'text'
     end
 
-    # Returns an instance of Logger
+    # Returns an instance of MonoLogger
     def build
-      logger = Logger.new(@log_dev)
+      logger = MonoLogger.new(@log_dev)
       logger.level = level
       logger.formatter = send(:"#{@format}_formatter")
       logger
@@ -38,11 +40,11 @@ module ResqueScheduler
 
     def level
       if @verbose && !@muted
-        Logger::DEBUG
+        MonoLogger::DEBUG
       elsif !@muted
-        Logger::INFO
+        MonoLogger::INFO
       else
-        Logger::FATAL
+        MonoLogger::FATAL
       end
     end
 

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop' unless RUBY_VERSION < '1.9'
   spec.add_development_dependency 'simplecov' unless RUBY_VERSION < '1.9'
 
+  spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '~> 3.0.4'
   spec.add_runtime_dependency 'resque', '~> 1.25.1'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 2.0.24'

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -12,7 +12,7 @@ context "Resque::Scheduler" do
   teardown { restore_devnull_logfile }
 
   test 'set custom logger' do
-    custom_logger = Logger.new('/dev/null')
+    custom_logger = MonoLogger.new('/dev/null')
     Resque::Scheduler.logger = custom_logger
     assert_equal(custom_logger, Resque::Scheduler.logger)
   end
@@ -62,11 +62,11 @@ context "Resque::Scheduler" do
     end
 
     test 'not verbose' do
-      assert Resque::Scheduler.logger.level > Logger::DEBUG
+      assert Resque::Scheduler.logger.level > MonoLogger::DEBUG
     end
 
     test 'not muted' do
-      assert Resque::Scheduler.logger.level < Logger::FATAL
+      assert Resque::Scheduler.logger.level < MonoLogger::FATAL
     end
   end
 
@@ -84,12 +84,12 @@ context "Resque::Scheduler" do
 
     test 'set verbosity' do
       Resque::Scheduler.verbose = true
-      assert Resque::Scheduler.logger.level == Logger::DEBUG
+      assert Resque::Scheduler.logger.level == MonoLogger::DEBUG
     end
 
     test 'mute logger' do
       Resque::Scheduler.mute = true
-      assert Resque::Scheduler.logger.level == Logger::FATAL
+      assert Resque::Scheduler.logger.level == MonoLogger::FATAL
     end
   end
 end


### PR DESCRIPTION
as this is what Resque uses and it _should_ help with odd bugs that crop up with Ruby 2 and traps.
