### PR TITLE
Allow deletion of scheduled jobs from resque web

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,6 +30,7 @@ Resque Scheduler authors
 - John Crepezzi
 - John Griffin
 - Jon Larkowski and Les Hill
+- Jonathan Conley
 - Jonathan Hyman
 - Jonathan Owens
 - Joshua Szmajda

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -17,6 +17,7 @@ module Resque
           post('/schedule/requeue_with_params') do
             schedule_requeue_with_params
           end
+          delete('/schedule') { delete_schedule }
           get('/delayed') { delayed }
           get('/delayed/jobs/:klass') { delayed_jobs_klass }
           post('/delayed/search') { delayed_search }
@@ -62,6 +63,14 @@ module Resque
           config = config.merge('args' => config_args)
           Resque::Scheduler.enqueue_from_config(config)
           redirect u('/overview')
+        end
+
+        def delete_schedule
+          if Resque::Scheduler.dynamic
+            job_name = params['job_name'] || params[:job_name]
+            Resque.remove_schedule(job_name)
+          end
+          redirect u('/schedule')
         end
 
         def delayed

--- a/lib/resque/scheduler/server/views/scheduler.erb
+++ b/lib/resque/scheduler/server/views/scheduler.erb
@@ -8,6 +8,9 @@
 <div style="overflow-y: auto; width:100%; padding: 0px 5px;">
 <table>
   <tr>
+    <% if Resque::Scheduler.dynamic %>
+      <th></th>
+    <% end %>
     <th></th>
     <th>Name</th>
     <th>Description</th>
@@ -20,6 +23,15 @@
   <% Resque.schedule.keys.sort.select { |n| scheduled_in_this_env?(n) }.each do |name| %>
     <% config = Resque.schedule[name] %>
     <tr>
+      <% if Resque::Scheduler.dynamic %>
+        <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
+          <form action="<%= u "/schedule" %>" method="post" style="margin-left: 0">
+            <input type="hidden" name="job_name" value="<%= h name %>">
+            <input type="hidden" name="_method" value="delete">
+            <input type="submit" value="Delete">
+          </form>
+        </td>
+      <% end %>
       <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
         <form action="<%= u "/schedule/requeue" %>" method="post" style="margin-left: 0">
           <input type="hidden" name="job_name" value="<%= h name %>">


### PR DESCRIPTION
This is a feature that my team has wanted for a while, so I went ahead and added it.  You can now go to the schedule tab and delete any job as long as you are running in dynamic mode.

The addition of the delete endpoint angered rubocop, so I factored out the helpers and lowered the max length config for methods.  How would you feel about adding a rubocop exception to the ResqueScheduler::Server.included method so that this method doesn't force an artificially high max line length?  It made sense to factor out the helpers, but the routes themselves seem okay as they are.

When I moved the helper methods into the module, rubocop complained that '[]' should be used instead of 'Array.new'.  I'm not sure why that was masked before.
