### PR TITLE
Loading the search_form.erb "partial" reliably

### DIFF
--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -5,6 +5,10 @@ require 'json'
 # Extend Resque::Server to add tabs
 module ResqueScheduler
   module Server
+    unless defined?(::ResqueScheduler::Server::VIEWS)
+      VIEWS = File.expand_path('../server/views', __FILE__)
+    end
+
     def self.included(base)
       base.class_eval do
         helpers do

--- a/lib/resque_scheduler/server/views/delayed.erb
+++ b/lib/resque_scheduler/server/views/delayed.erb
@@ -1,7 +1,7 @@
 <h1>Delayed Jobs</h1>
 <%- size = resque.delayed_queue_schedule_size %>
 
-<%= erb File.read(File.join(File.dirname(__FILE__), 'server/views/search_form.erb')) %>
+<%= erb File.read(File.join(ResqueScheduler::Server::VIEWS, 'search_form.erb')) %>
 
 <p class='intro'>
   This list below contains the timestamps for scheduled delayed jobs.

--- a/lib/resque_scheduler/server/views/search.erb
+++ b/lib/resque_scheduler/server/views/search.erb
@@ -1,5 +1,5 @@
 <h1>Search Results</h1>
-<%= erb File.read(File.join(File.dirname(__FILE__), 'server/views/search_form.erb')) %>
+<%= erb File.read(File.join(ResqueScheduler::Server::VIEWS, 'search_form.erb')) %>
 <hr>
 <% delayed = @jobs.select { |j| j['where_at'] == 'delayed' } %>
 <h1>Delayed jobs</h1>


### PR DESCRIPTION
when stuff like newrelic_rpm is is the mix, which hoses dependence on `__FILE__` even when NEWRELIC_ENABLED=false.
