### PR TITLE
Autoload VERSION constant

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -11,6 +11,7 @@ module Resque
     autoload :Cli, 'resque/scheduler/cli'
     autoload :Extension, 'resque/scheduler/extension'
     autoload :Util, 'resque/scheduler/util'
+    autoload :VERSION, 'resque/scheduler/version'
 
     private
 


### PR DESCRIPTION
In order to fix the "NameError: uninitialized constant Resque::Scheduler::VERSION" I added it to the autoload, but it might be a good idea to just require it instead.
