### PR TITLE
Switch from ruby 2.1.0 to 2.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,20 +1,17 @@
 language: ruby
 rvm:
-- 1.9.3
-- 2.0.0
-- 2.1.0
-- jruby-19mode
-- rbx
+- '1.9.3'
+- '2.1'
+- 'jruby-19mode'
+- 'rbx'
 env:
   global:
   - RESQUE_SCHEDULER_DISABLE_TEST_REDIS_SERVER=1
   - JRUBY_OPTS='-Xcext.enabled=true'
 matrix:
   allow_failures:
-  - rvm: jruby-19mode
-  - rvm: rbx
-  # 2.1.0 is currently hosed :scream_cat:
-  - rvm: 2.1.0
+  - rvm: 'jruby-19mode'
+  - rvm: 'rbx'
 services:
 - redis-server
 notifications:


### PR DESCRIPTION
as the 2.1.0 binary install is currently busted, but 2.1.1 is fine.
