### PR TITLE
Added single helper to preview arguments.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -70,3 +70,4 @@ Resque Scheduler authors
 - hpoydar
 - malomalo
 - sawanoboly
+- serek

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -129,6 +129,10 @@ module Resque
           t.strftime('%Y-%m-%d %H:%M:%S %z')
         end
 
+        def show_job_arguments(args)
+          Array(args).map { |a| a.inspect }.join("\n")
+        end
+
         def queue_from_class_name(class_name)
           Resque.queue_from_class(
             Resque::Scheduler::Util.constantize(class_name)

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -39,7 +39,7 @@
           <a href="<%= u "delayed/#{timestamp}" %>">see details</a>
         <% end %>
       </td>
-      <td><%= h(job['args'].inspect) if job && delayed_timestamp_size == 1 %></td>
+      <td><%= h(show_job_arguments(job['args'])) if job && delayed_timestamp_size == 1 %></td>
       <td>
         <% if job %>
           <a href="<%=u URI("/delayed/jobs/#{job['class']}?args=" + URI.encode(job['args'].to_json)) %>">All schedules</a>

--- a/lib/resque/scheduler/server/views/delayed_schedules.erb
+++ b/lib/resque/scheduler/server/views/delayed_schedules.erb
@@ -1,4 +1,4 @@
-<h1>Delayed jobs scheduled for <%= params[:klass] %> (<%= @args %>)</h1>
+<h1>Delayed jobs scheduled for <%= params[:klass] %> (<%= show_job_arguments(@args) %>)</h1>
 
 <table class='jobs'>
 <tr>

--- a/lib/resque/scheduler/server/views/delayed_timestamp.erb
+++ b/lib/resque/scheduler/server/views/delayed_timestamp.erb
@@ -13,7 +13,7 @@
   <% jobs.each do |job| %>
     <tr>
       <td class='class'><%= job['class'] %></td>
-      <td class='args'><%=h job['args'].inspect %></td>
+      <td class='args'><%=h show_job_arguments(job['args']) %></td>
     </tr>
   <% end %>
   <% if jobs.empty? %>

--- a/lib/resque/scheduler/server/views/scheduler.erb
+++ b/lib/resque/scheduler/server/views/scheduler.erb
@@ -43,7 +43,7 @@
       <td style="white-space:nowrap"><%= h schedule_interval(config) %></td>
       <td><%= h schedule_class(config) %></td>
       <td><%= h config['queue'] || queue_from_class_name(config['class']) %></td>
-      <td><%= h config['args'].inspect %></td>
+      <td><%= h show_job_arguments(config['args']) %></td>
       <td><%= h Resque.get_last_enqueued_at(name) || 'Never' %></td>
     </tr>
   <% end %>

--- a/lib/resque/scheduler/server/views/search.erb
+++ b/lib/resque/scheduler/server/views/search.erb
@@ -23,7 +23,7 @@
           <form action="<%= u "/delayed/cancel_now" %>" method="post">
             <input type="hidden" name="timestamp" value="<%= job['timestamp'].to_i %>">
             <input type="hidden" name="klass" value="<%= job['class'] %>">
-            <input type="hidden" name="args" value="<%= Resque.encode job['args'] %>">
+            <input type="hidden" name="args" value="<%= Resque.encode show_job_arguments(job['args']) %>">
             <input type="submit" value="Cancel Job">
           </form>
         </td>

--- a/lib/resque/scheduler/server/views/search.erb
+++ b/lib/resque/scheduler/server/views/search.erb
@@ -23,7 +23,7 @@
           <form action="<%= u "/delayed/cancel_now" %>" method="post">
             <input type="hidden" name="timestamp" value="<%= job['timestamp'].to_i %>">
             <input type="hidden" name="klass" value="<%= job['class'] %>">
-            <input type="hidden" name="args" value="<%= Resque.encode show_job_arguments(job['args']) %>">
+            <input type="hidden" name="args" value="<%= Resque.encode job['args'] %>">
             <input type="submit" value="Cancel Job">
           </form>
         </td>


### PR DESCRIPTION
With that kind of helper it's easy to override it in any rails application to maintain potential security issue on production environments where many of arguments might be considered harmful when seen.

Example in Rails:
```ruby
FILE: config/initializers/resque_web.rb

module Resque
  class Server
    helpers do
      def show_job_arguments(args)
        Array(args).map do |a|
          if a.is_a?(Hash)
            ActionDispatch::Http::ParameterFilter.new(Rails.application.config.filter_parameters).filter(a)
          else
            a
          end
        end.inspect
      end
    end
  end
end
```

This way someone can filter confidential data just from his application.rb configuration for the same params that are filtered across the app and logs.