### PR TITLE
Update README.md for Issue #411

### DIFF
--- a/README.md
+++ b/README.md
@@ -602,7 +602,7 @@ vagrant up
 ### Deployment Notes
 
 It is recommended that a production deployment of resque_scheduler be hosted on
-a dedicated Redis cluster.  While making and managing scheduled tasks, 
+a dedicated Redis database.  While making and managing scheduled tasks, 
 resque_scheudler currently scans the entire Redis keyspace, which may cause latency 
 and stability issues if resque_scheduler is hosted on a Redis instance storing a large 
 number of keys (such as those written by a different system hosted on the same Redis instance).


### PR DESCRIPTION
Per the discussion in https://github.com/resque/resque-scheduler/issues/411, this adds a stanza to the README to describe the recommended production configuration for resque_schedule (i.e. providing a dedicated Redis instance that isn't cluttered with keys from other systems).
