### PR TITLE
Fix remove_delayed_selection to ignore last_enqueued_at redis key

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ Resque Scheduler authors
 - Henrik Nyh
 - James Le Cuirot
 - Jarkko Mönkkönen
+- Jason Gellatly
 - John Crepezzi
 - John Griffin
 - Jon Larkowski and Les Hill

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -178,6 +178,10 @@ module Resque
         # so we query for all delayed job tasks and do our matching after
         # decoding the payload data
         jobs = Resque.redis.keys('delayed:*')
+
+        # Ignore redis key set by last_enqueued_at
+        jobs.reject! { |j| j.end_with?('last_enqueued_at') }
+
         jobs.each do |job|
           index = Resque.redis.llen(job) - 1
           while index >= 0

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -436,6 +436,15 @@ context 'DelayedQueue' do
     assert_equal(4, Resque.count_all_scheduled_jobs)
   end
 
+  test 'remove_delayed_selection ignores last_enqueued_at redis key' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.last_enqueued_at(SomeIvarJob, t)
+
+    assert_equal(0, Resque.remove_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(1, Resque.count_all_scheduled_jobs)
+  end
+
   test "remove_delayed_selection doesn't remove items it shouldn't" do
     t = Time.now + 120
     Resque.enqueue_at(t, SomeIvarJob, 'foo')


### PR DESCRIPTION
When `remove_delayed_selection` encounters the `last_enqueued_at` redis key, it explodes violently with the error:

```
Redis::CommandError:
    ERR Operation against a key holding the wrong kind of value
```

This PR fixes it by rejecting the key from the jobs set in `remove_delayed_selection`, and adds a test to ensure that it passes when the key exists.

Also took the liberty of adding myself to the AUTHORS.md, because apparently that's part of the PR guidelines ;)
