### PR TITLE
Avoid Redis KEYS in remove_delayed_selection

### DIFF
--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -447,6 +447,15 @@ context 'DelayedQueue' do
     assert_equal(4, Resque.count_all_scheduled_jobs)
   end
 
+  test 'remove_delayed_selection ignores last_enqueued_at redis key' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.last_enqueued_at(SomeIvarJob, t)
+
+    assert_equal(0, Resque.remove_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob))
+  end
+
   test 'remove_delayed_job_from_timestamp removes instances of jobs ' \
        'at a given timestamp' do
     t = Time.now + 120


### PR DESCRIPTION
Do not use Redis KEYS command in Resque.remove_delayed_selection,
iterate through all timestamps instead.

Note that it can takes a lot of time to execute and also you might
consider what happens if you try to delete all delayed matching a given
selection criteria, while someone else is going to add new jobs.

CREDITS:
- @yaauie for the first draft in #411
- @xyzjace for following up in #415
- @potomak to help in debugging issues with the provided PR
- @dankoch for reporting #411
