### PR TITLE
pidfile: ensure English is required in Env, where it is needed for $PROCESS_ID

### DIFF
--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -1,5 +1,7 @@
 # vim:fileencoding=utf-8
 
+require 'English' # $PROCESS_ID
+
 module Resque
   module Scheduler
     class Env

--- a/lib/resque/scheduler/tasks.rb
+++ b/lib/resque/scheduler/tasks.rb
@@ -1,6 +1,5 @@
 # vim:fileencoding=utf-8
 
-require 'English'
 require 'resque/tasks'
 require 'resque-scheduler'
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -33,7 +33,7 @@ context 'Env' do
 
   test 'writes pid to pidfile when given' do
     mock_pidfile = mock('pidfile')
-    mock_pidfile.expects(:puts)
+    mock_pidfile.expects(:puts).with(Process.pid)
     File.expects(:open).with('derp.pid', 'w').yields(mock_pidfile)
     env = new_env(pidfile: 'derp.pid')
     env.setup


### PR DESCRIPTION
As @mdahlstrand pointed out in #418, pidfile is broken unless using the rake task.

It looks like it [relies on `$PROCESS_ID`](https://github.com/resque/resque-scheduler/blob/v3.0.0/lib/resque/scheduler/env.rb#L40), which is provided by the `English` library in stdlib, but we only require it [in the rake task](https://github.com/resque/resque-scheduler/blob/v3.0.0/lib/resque/scheduler/tasks.rb#L3) :frowning:

``` irb
irb(main):001:0> $$
=> 34631
irb(main):002:0> $PROCESS_ID
=> nil
irb(main):003:0> require 'English'
=> true
irb(main):004:0> $PROCESS_ID
=> 34631
```

This patch fixes the issue on 3.x, and should be backported to 2.5.x as well; I'll gladly manage that legwork once someone reviews the fix.

Resolves #418
