### PR TITLE
Remove pidfile on exit. Fixes #416.

### DIFF
--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -38,6 +38,9 @@ module Resque
       def setup_pid_file
         File.open(options[:pidfile], 'w') do |f|
           f.puts $PROCESS_ID
+          at_exit do
+            File.delete f
+          end
         end if options[:pidfile]
       end
 


### PR DESCRIPTION
This was the simplest solution for fixing the issue. As I'm not a ruby dev, please have a look and let me know if I should change anything!

Potential issues:
- If the pidfile is removed while resque-scheduler is still running, it throws an error. I thought this could be a good thing, as something else probably is up if the pidfile is removed while the program is still running.
- As I'm not a ruby developer, I don't know if it's bad to add the at_exit hook directly inside the file handler. I'm thinking it might lead to it being left open too long or something. Please let me know.

Also, a quick question, why is `$PROCESS_ID` used instead of `Process.id`?

Thanks,
Magnus
