### PR TITLE
Remove reference to specify require in gemfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ To install:
 
     gem install resque-scheduler
 
-If you use a Gemfile, you may want to specify the `:require` explicitly:
+If you use a Gemfile:
 
 ```ruby
 gem 'resque-scheduler'


### PR DESCRIPTION
Since explicitly specifying `:require` in the Gemfile should no longer
be necessary, referencing it seems contradictory and might confuse users.
