### PR TITLE
Issue 434 - enabling poll sleep loop to break out with TERM signals when sleep amount = 0

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -54,6 +54,7 @@ Resque Scheduler authors
 - Ryan Carver
 - Sameer Siruguri
 - Scott Francis
+- Sean Stephens
 - Sebastian Kippe
 - Spring MC
 - Tim Liner

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -325,22 +325,36 @@ module Resque
 
       def poll_sleep_loop
         @sleeping = true
-        start = Time.now
-        loop do
-          elapsed_sleep = (Time.now - start)
-          remaining_sleep = poll_sleep_amount - elapsed_sleep
-          break if remaining_sleep <= 0
-          begin
-            sleep(remaining_sleep)
-            handle_signals
-          rescue Interrupt
-            if @shutdown
-              Resque.clean_schedules
-              release_master_lock!
+        if @poll_sleep_amount > 0
+          start = Time.now
+          loop do
+            elapsed_sleep = (Time.now - start)
+            remaining_sleep = @poll_sleep_amount - elapsed_sleep
+            @do_break = false
+            if remaining_sleep <= 0
+              @do_break = true
+            else
+              @do_break = handle_signals_with_operation do
+                sleep(remaining_sleep)
+              end
             end
-            break
+            break if @do_break
           end
+        else
+          handle_signals_with_operation {}
         end
+      end
+
+      def handle_signals_with_operation
+        yield
+        handle_signals
+        false
+        rescue Interrupt
+          if @shutdown
+            Resque.clean_schedules
+            release_master_lock!
+          end
+          true
       end
 
       # Sets the shutdown flag, clean schedules and exits if sleeping

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -37,4 +37,22 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.unstub(:release_master_lock!)
     Resque::Scheduler.release_master_lock!
   end
+
+  test 'sending TERM to scheduler breaks out when poll_sleep_amount = 0' do
+    Resque::Scheduler.poll_sleep_amount = 0
+    Resque::Scheduler.expects(:release_master_lock!)
+
+    @pid = Process.pid
+    Thread.new do
+      sleep(0.05)
+      Process.kill(:TERM, @pid)
+    end
+
+    assert_raises SystemExit do
+      Resque::Scheduler.run
+    end
+
+    Resque::Scheduler.unstub(:release_master_lock!)
+    Resque::Scheduler.release_master_lock!
+  end
 end


### PR DESCRIPTION
The poll_sleep_loop will not exit on kill -s TERM commands to the scheduler process. This is because the check for whether the sleep time has passed does a break without running handle signals, assuming there will be a time at some point where remaining_sleep will be > 0. This can't be met with poll_sleep_amount set to 0.

I updated the code to check for 0 and explicity run the handle_signals code. This caused repetition so I pulled the handle_signals code block out into a method that can accept a block to run before handle_signals is called. I also added a test for this case.