### PR TITLE
reload_schedule! returns nil with no job in queue

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -292,7 +292,8 @@ module Resque
           loop do
             schedule_name = Resque.redis.spop(:schedules_changed)
             break unless schedule_name
-            if Resque.reload_schedule!.keys.include?(schedule_name)
+            Resque.reload_schedule!
+            if Resque.schedule.keys.include?(schedule_name)
               unschedule_job(schedule_name)
               load_schedule_job(schedule_name, Resque.schedule[schedule_name])
             else

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -210,6 +210,26 @@ context 'Resque::Scheduler' do
     assert_equal 0, Resque.redis.scard(:schedules_changed)
   end
 
+  test 'update_schedule when all jobs have been removed' do
+    Resque::Scheduler.dynamic = true
+    Resque.schedule = {
+      'some_ivar_job' => {
+        'cron' => '* * * * *', 'class' => 'SomeIvarJob', 'args' => '/tmp'
+      }
+    }
+
+    Resque::Scheduler.load_schedule!
+
+    Resque.remove_schedule('some_ivar_job')
+
+    Resque::Scheduler.update_schedule
+
+    assert_equal(0, Resque::Scheduler.rufus_scheduler.all_jobs.size)
+    assert_equal(0, Resque::Scheduler.scheduled_jobs.size)
+    assert_equal([], Resque::Scheduler.scheduled_jobs.keys)
+    assert_equal 0, Resque.redis.scard(:schedules_changed)
+  end
+
   test 'update_schedule with mocks' do
     Resque::Scheduler.dynamic = true
     Resque.schedule = {


### PR DESCRIPTION
The reload_schedule! method invoked in update_schedule returns nil if no
more job is in the queue. Access the schedule Hash instead.

Fixes #430
