### PR TITLE
Lock Rubocop version and make it happy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,5 @@ Documentation:
 
 Style/DoubleNegation:
   Enabled: false
+Style/PerceivedComplexity:
+  Enabled: false

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
-  spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'rubocop', '~> 0.25.0'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'yard'
 

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -174,17 +174,17 @@ context 'POST /schedule/requeue' do
     assert last_response.ok?, last_response.errors
     assert last_response.body.include?('This job requires parameters')
     assert last_response.body.include?(
-      %Q(<input type="hidden" name="job_name" value="#{job_name}">)
+      %(<input type="hidden" name="job_name" value="#{job_name}">)
     )
 
     Resque.schedule[job_name]['parameters'].each do |_param_name, param_config|
       assert last_response.body.include?(
         '<span style="border-bottom:1px dotted;" ' <<
-        %Q[title="#{param_config['description']}">(?)</span>]
+        %[title="#{param_config['description']}">(?)</span>]
       )
       assert last_response.body.include?(
         '<input type="text" name="log_level" ' <<
-        %Q(value="#{param_config['default']}">)
+        %(value="#{param_config['default']}">)
       )
     end
   end


### PR DESCRIPTION
- Lock Rubocop version to 0.25.0
- Disable PerceivedComplexity check
- Fix minor issues in tests

Locking, as suggested by @meatballhat,  is useful to avoid difference between dev local settings and Travis CI one. As soon as this will get merged a rebase of #442 should solve the Travis complains for that PR.
