### PR TITLE
Fix delayed queue now behaviour

### DIFF
--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -101,7 +101,8 @@ module Resque
         def delayed_queue_now
           timestamp = params['timestamp'].to_i
           if timestamp > 0
-            Resque::Scheduler.enqueue_delayed_items_for_timestamp(timestamp)
+            next_item = Resque.next_item_for_timestamp(timestamp)
+            Resque::Scheduler.enqueue_from_config(next_item)
           end
           redirect u('/overview')
         end


### PR DESCRIPTION
Hi, I found "Queue now" on Delayed server panel to never queue a future job for me.

A way to make it work, was to not call `Resque::Scheduler.enqueue_delayed_items_for_timestamp` and bypass the is_master? check. Seems the master lock is never acquired when calling `Resque::Scheduler::Server.delayed_queue_now`.

I might doing the wrong thing here, but I would like to get some feedback on this if possible.
Why queue now might not work for me? Are there some corner cases I am missing here?
