### PR TITLE
Use constant and helper to load erb search_form.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -34,6 +34,7 @@ Resque Scheduler authors
 - Joshua Szmajda
 - Justin Weiss
 - Les Hill
+- Luke Rodgers
 - Manuel Meurer
 - Matt Aimonetti
 - Matt Simpson

--- a/lib/resque_scheduler/server.rb
+++ b/lib/resque_scheduler/server.rb
@@ -5,6 +5,9 @@ require 'json'
 # Extend Resque::Server to add tabs
 module ResqueScheduler
   module Server
+    unless defined?(::ResqueScheduler::Server::VIEW_PATH)
+      VIEW_PATH = File.join(File.dirname(__FILE__), 'server', 'views')
+    end
     def self.included(base)
       base.class_eval do
         helpers do
@@ -86,6 +89,10 @@ module ResqueScheduler
           def scheduled_in_this_env?(name)
             return true if Resque.schedule[name]['rails_env'].nil?
             Resque.schedule[name]['rails_env'] == Resque::Scheduler.env
+          end
+
+          def scheduler_view filename, options = {}, locals = {}
+            erb(File.read(File.join(VIEW_PATH, "#{filename}.erb")), options, locals)
           end
         end
 

--- a/lib/resque_scheduler/server/views/delayed.erb
+++ b/lib/resque_scheduler/server/views/delayed.erb
@@ -1,7 +1,7 @@
 <h1>Delayed Jobs</h1>
 <%- size = resque.delayed_queue_schedule_size %>
 
-<%= erb File.read(File.join(File.dirname(__FILE__), 'server/views/search_form.erb')) %>
+<%= scheduler_view :search_form %>
 
 <p class='intro'>
   This list below contains the timestamps for scheduled delayed jobs.

--- a/lib/resque_scheduler/server/views/search.erb
+++ b/lib/resque_scheduler/server/views/search.erb
@@ -1,5 +1,5 @@
 <h1>Search Results</h1>
-<%= erb File.read(File.join(File.dirname(__FILE__), 'server/views/search_form.erb')) %>
+<%= scheduler_view :search_form %>
 <hr>
 <% delayed = @jobs.select { |j| j['where_at'] == 'delayed' } %>
 <h1>Delayed jobs</h1>


### PR DESCRIPTION
This PR addresses the issue outlined in #378. The fix there in fact worked for me as well, and this patch is based on that solution as well as quirkey/resque-status@fc3fe36.

This branch is based off the v2.5.5 tag -- I know resque-scheduler's at 3.0.0, but if this could get backported/released as v2.5.6, that would awesome.

(Originally opened here: https://github.com/resque/resque-scheduler/pull/445)
