### PR TITLE
Change recommended way of loading schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,13 +71,14 @@ require 'resque/scheduler/tasks'
 namespace :resque do
   task :setup do
     require 'resque'
-    require 'resque-scheduler'
 
     # you probably already have this somewhere
     Resque.redis = 'localhost:6379'
   end
   
-  task setup_schedule do
+  task :setup_schedule => :setup do
+    require 'resque-scheduler'
+
     # If you want to be able to dynamically change the schedule,
     # uncomment this line.  A dynamic schedule can be updated via the
     # Resque::Scheduler.set_schedule (and remove_schedule) methods.
@@ -98,7 +99,7 @@ namespace :resque do
     require 'jobs'
   end
   
-  task scheduler_setup: :setup_schedule
+  task :scheduler_setup => :setup_schedule
 end
 ```
 


### PR DESCRIPTION
When schedule is loaded in resque:setup task, all resque process irrespective of if they are the scheduler or not will try to reload the schedule. 

Not only is this an unnecessary overhead, but it also causes a race condition in setting the schedule which was fixed recently in #439. Since this fix is not yet available on rubygems, it best to tell user to only run one instance of the scheduler and do it like this.
