### PR TITLE
enqueue_delayed_selection

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -57,6 +57,7 @@ Resque Scheduler authors
 - Scott Francis
 - Sebastian Kippe
 - Spring MC
+- tbprojects
 - Tim Liner
 - Tony Lewis
 - Tom Crayford

--- a/README.md
+++ b/README.md
@@ -220,6 +220,17 @@ Resque.remove_delayed_selection { |args| args[0]['account_id'] == current_accoun
 Resque.remove_delayed_selection { |args| args[0]['user_id'] == current_user.id }
 ```
 
+If you need to enqueue immediately a delayed job based on some matching arguments, but don't wish to specify each argument from when the job was created, you can do like so:
+
+``` ruby
+# after you've enqueued a job like:
+Resque.enqueue_at(5.days.from_now, SendFollowUpEmail, :account_id => current_account.id, :user_id => current_user.id)
+# enqueue immediately jobs matching just the account:
+Resque.enqueue_delayed_selection { |args| args[0]['account_id'] == current_account.id }
+# or enqueue immediately jobs matching just the user:
+Resque.enqueue_delayed_selection { |args| args[0]['user_id'] == current_user.id }
+```
+
 ### Scheduled Jobs (Recurring Jobs)
 
 Scheduled (or recurring) jobs are logically no different than a standard cron

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -179,6 +179,33 @@ module Resque
         end
       end
 
+      # Given a block, find jobs that return true from a block
+      #
+      # This allows for finding of delayed jobs that have arguments matching
+      # certain criteria
+      def find_delayed_selection(klass = nil)
+        fail ArgumentError, 'Please supply a block' unless block_given?
+
+        found_jobs = []
+        start = nil
+        while start = search_first_delayed_timestamp_in_range(start, nil)
+          job = "delayed:#{start}"
+          start += 1
+          index = Resque.redis.llen(job) - 1
+          while index >= 0
+            payload = Resque.redis.lindex(job, index)
+            decoded_payload = decode(payload)
+            job_class = decoded_payload['class']
+            relevant_class = (klass.nil? || klass.to_s == job_class)
+            if relevant_class && yield(decoded_payload['args'])
+              found_jobs.push(payload)
+            end
+            index -= 1
+          end
+        end
+        found_jobs
+      end
+
       # Given a timestamp and job (klass + args) it removes all instances and
       # returns the count of jobs removed.
       #
@@ -278,29 +305,6 @@ module Resque
         )
         timestamp = items.nil? ? nil : Array(items).first
         timestamp.to_i unless timestamp.nil?
-      end
-
-      def find_delayed_selection(klass = nil)
-        fail ArgumentError, 'Please supply a block' unless block_given?
-
-        found_jobs = []
-        start = nil
-        while start = search_first_delayed_timestamp_in_range(start, nil)
-          job = "delayed:#{start}"
-          start += 1
-          index = Resque.redis.llen(job) - 1
-          while index >= 0
-            payload = Resque.redis.lindex(job, index)
-            decoded_payload = decode(payload)
-            job_class = decoded_payload['class']
-            relevant_class = (klass.nil? || klass.to_s == job_class)
-            if relevant_class && yield(decoded_payload['args'])
-              found_jobs.push(payload)
-            end
-            index -= 1
-          end
-        end
-        found_jobs
       end
 
       def plugin

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -659,6 +659,143 @@ context 'DelayedQueue' do
     assert_equal(2, Resque.count_all_scheduled_jobs)
   end
 
+  test 'find_delayed_selection finds multiple items matching ' \
+       'arguments at same timestamp' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'monkey')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'platypus')
+    Resque.enqueue_at(t, SomeIvarJob, 'baz')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+
+    assert_equal(5, (Resque.find_delayed_selection do |a|
+      a.first == 'bar'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds single item matching arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(1, (Resque.find_delayed_selection do |a|
+      a.first == 'foo'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds multiple items matching arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(2, (Resque.find_delayed_selection do |a|
+      a.first == 'bar'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds multiple items matching ' \
+       'arguments as hash' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, foo: 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, foo: 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, foo: 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, foo: 'baz')
+
+    assert_equal(
+        2, (Resque.find_delayed_selection do |a|
+          a.first['foo'] == 'bar'
+        end).length
+    )
+  end
+
+  test 'find_delayed_selection ignores jobs with no arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.enqueue_at(t + 1, SomeIvarJob)
+    Resque.enqueue_at(t + 2, SomeIvarJob)
+    Resque.enqueue_at(t + 3, SomeIvarJob)
+
+    assert_equal(0, (Resque.find_delayed_selection do |a|
+      a.first == 'bar'
+    end).length)
+  end
+
+  test "find_delayed_selection doesn't find items it shouldn't" do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(0, (Resque.find_delayed_selection do |a|
+      a.first == 'qux'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds item by class' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, (Resque.find_delayed_selection(SomeIvarJob) do |a|
+      a.first == 'foo'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds item by class name as a string' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, (Resque.find_delayed_selection('SomeIvarJob') do |a|
+      a.first == 'foo'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds item by class name as a symbol' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, (Resque.find_delayed_selection(:SomeIvarJob) do |a|
+      a.first == 'foo'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds items only from' \
+       'matching job class' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 1, SomeQuickJob, 'bar')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 2, SomeQuickJob, 'foo')
+
+    assert_equal(2, (Resque.find_delayed_selection(SomeIvarJob) do |a|
+      a.first == 'foo'
+    end).length)
+  end
+
+  test 'find_delayed_selection finds items from matching job class ' \
+       'without params' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.enqueue_at(t + 1, SomeQuickJob)
+    Resque.enqueue_at(t + 2, SomeIvarJob)
+    Resque.enqueue_at(t + 3, SomeQuickJob)
+
+    assert_equal(
+        2, (Resque.find_delayed_selection(SomeQuickJob) { true }).length
+    )
+  end
+
   test 'remove_delayed_job_from_timestamp removes instances of jobs ' \
        'at a given timestamp' do
     t = Time.now + 120

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -516,6 +516,149 @@ context 'DelayedQueue' do
     assert_equal(2, Resque.count_all_scheduled_jobs)
   end
 
+  test 'enqueue_delayed_selection enqueues multiple items matching ' \
+       'arguments at same timestamp' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'monkey')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'platypus')
+    Resque.enqueue_at(t, SomeIvarJob, 'baz')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+    Resque.enqueue_at(t, SomeIvarJob, 'bar', 'llama')
+
+    assert_equal(5, Resque.enqueue_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues single item matching arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(1, Resque.enqueue_delayed_selection { |a| a.first == 'foo' })
+    assert_equal(3, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues multiple items matching arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(2, Resque.enqueue_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues multiple items matching ' \
+       'arguments as hash' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, foo: 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, foo: 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, foo: 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, foo: 'baz')
+
+    assert_equal(
+        2, Resque.enqueue_delayed_selection { |a| a.first['foo'] == 'bar' }
+    )
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection ignores jobs with no arguments' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.enqueue_at(t + 1, SomeIvarJob)
+    Resque.enqueue_at(t + 2, SomeIvarJob)
+    Resque.enqueue_at(t + 3, SomeIvarJob)
+
+    assert_equal(0, Resque.enqueue_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(4, Resque.count_all_scheduled_jobs)
+  end
+
+  test "enqueue_delayed_selection doesn't enqueue items it shouldn't" do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 2, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 3, SomeIvarJob, 'baz')
+
+    assert_equal(0, Resque.enqueue_delayed_selection { |a| a.first == 'qux' })
+    assert_equal(4, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection ignores last_enqueued_at redis key' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.last_enqueued_at(SomeIvarJob, t)
+
+    assert_equal(0, Resque.enqueue_delayed_selection { |a| a.first == 'bar' })
+    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob))
+  end
+
+  test 'enqueue_delayed_selection enqueues item by class' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, Resque.enqueue_delayed_selection(SomeIvarJob) do |a|
+      a.first == 'foo'
+    end)
+    assert_equal(1, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues item by class name as a string' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, Resque.enqueue_delayed_selection('SomeIvarJob') do |a|
+      a.first == 'foo'
+    end)
+    assert_equal(1, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues item by class name as a symbol' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+
+    assert_equal(1, Resque.enqueue_delayed_selection(:SomeIvarJob) do |a|
+      a.first == 'foo'
+    end)
+    assert_equal(1, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues items only from' \
+       'matching job class' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeQuickJob, 'foo')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'bar')
+    Resque.enqueue_at(t + 1, SomeQuickJob, 'bar')
+    Resque.enqueue_at(t + 1, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t + 2, SomeQuickJob, 'foo')
+
+    assert_equal(2, Resque.enqueue_delayed_selection(SomeIvarJob) do |a|
+      a.first == 'foo'
+    end)
+    assert_equal(4, Resque.count_all_scheduled_jobs)
+  end
+
+  test 'enqueue_delayed_selection enqueues items from matching job class ' \
+       'without params' do
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.enqueue_at(t + 1, SomeQuickJob)
+    Resque.enqueue_at(t + 2, SomeIvarJob)
+    Resque.enqueue_at(t + 3, SomeQuickJob)
+
+    assert_equal(2, Resque.enqueue_delayed_selection(SomeQuickJob) { true })
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+  end
+
   test 'remove_delayed_job_from_timestamp removes instances of jobs ' \
        'at a given timestamp' do
     t = Time.now + 120


### PR DESCRIPTION
One of the nice features is `remove_delayed_selection` which allows to filter jobs to be removed. I needed similar filtration functionality but for immediate enqueuing delayed jobs, that are already queued.

In addition I extracted filtration to separate method - `find_delayed_selection`