### PR TITLE
Memoized runtime_env in order to prevent premature garbage collection of Env instance, which leads to pidfile getting deleted while resque-scheduler is still running.

### DIFF
--- a/lib/resque/scheduler/cli.rb
+++ b/lib/resque/scheduler/cli.rb
@@ -122,7 +122,7 @@ module Resque
       attr_reader :argv, :env
 
       def runtime_env
-        @runtime_env = Resque::Scheduler::Env.new(options)
+        @runtime_env ||= Resque::Scheduler::Env.new(options)
       end
 
       def option_parser


### PR DESCRIPTION
The premature deletion of the pidfile, in my experience, happens on RedHat 5.5, but does not happen on RedHat 6.5.
