### PR TITLE
Check alive in the safe way

### DIFF
--- a/lib/resque/scheduler/signal_handling.rb
+++ b/lib/resque/scheduler/signal_handling.rb
@@ -18,7 +18,7 @@ module Resque
             signal_queue << sig
             # break sleep in the primary scheduler thread, alowing
             # the signal queue to get processed as soon as possible.
-            @th.wakeup if @th.alive?
+            @th.wakeup if @th && @th.alive?
           end
         end
       end


### PR DESCRIPTION
Hi,

It seems that `@th` is not defined yet if the process gets the signal as soon as it starts. I think we don't want to get an exception for this.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resque/resque-scheduler/463)
<!-- Reviewable:end -->
