### PR TITLE
Note about Resque.redis config

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,17 @@ default `'text'`)
 * `VERBOSE` - Maximize log verbosity if non-empty (equivalent to a level
 of `MonoLogger::DEBUG`, default `false`)
 
+*Warning: If you use a different redis database, other than the default database (0), to store your redis jobs, you will have store the Resque.redis into the initializer file*
+
+```
+resque-scheduler [other options] --initializer-path script/resque-scheduler.init.rb
+```
+
+```ruby
+# script/resque-scheduler.init.rb
+require 'resque'
+Resque.redis = Redis.connect url: 'redis://localhost:6379/X'.freeze  # Where X is the selected redis database number
+```
 
 ### Resque Pool integration
 


### PR DESCRIPTION
In regards to #468.  I missed that resque-scheduler was *completely* stand-alone and wouldn't catch on I use a different redis database for resque jobs.

I've added this warning in the hopes that other people who also use a different redis database like will avoid this problem.