### PR TITLE
Fix scheduler settings

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@ Resque Scheduler authors
 - David Doan
 - David Yang
 - Denis Yagofarov
+- dtaniwaki
 - Evan Tahler
 - Eugene Batogov
 - Giovanni Cappellotto

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -56,24 +56,14 @@ module Resque
 
       def setup_scheduler_configuration
         Resque::Scheduler.configure do |c|
-          if (app_name = options[:app_name]) && !app_name.nil?
-            c.app_name = app_name
+          [:app_name, :env, :logfile, :logformat].each do |sym|
+            if (v = options[sym]) && !v.nil?
+              c.public_send "#{sym}=", v
+            end
           end
 
           if (dynamic = options[:dynamic]) && !dynamic.nil?
             c.dynamic = !!dynamic
-          end
-
-          if (env = options[:env]) && !env.nil?
-            c.env = env
-          end
-
-          if (logfile = options[:logfile]) && !logfile.nil?
-            c.logfile = logfile
-          end
-
-          if (logformat = options[:logformat]) && !logformat.nil?
-            c.logformat = logformat
           end
 
           if (psleep = options[:poll_sleep_amount]) && !psleep.nil?

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -56,32 +56,32 @@ module Resque
 
       def setup_scheduler_configuration
         Resque::Scheduler.configure do |c|
-          if options.key?(:app_name)
-            c.app_name = options[:app_name]
+          if (app_name = options[:app_name]) && !app_name.nil?
+            c.app_name = app_name
           end
 
-          if options.key?(:dynamic)
-            c.dynamic = !!options[:dynamic]
+          if (dynamic = options[:dynamic]) && !dynamic.nil?
+            c.dynamic = !!dynamic
           end
 
-          if options.key(:env)
-            c.env = options[:env]
+          if (env = options[:env]) && !env.nil?
+            c.env = env
           end
 
-          if options.key?(:logfile)
-            c.logfile = options[:logfile]
+          if (logfile = options[:logfile]) && !logfile.nil?
+            c.logfile = logfile
           end
 
-          if options.key?(:logformat)
-            c.logformat = options[:logformat]
+          if (logformat = options[:logformat]) && !logformat.nil?
+            c.logformat = logformat
           end
 
-          if psleep = options[:poll_sleep_amount] && !psleep.nil?
+          if (psleep = options[:poll_sleep_amount]) && !psleep.nil?
             c.poll_sleep_amount = Float(psleep)
           end
 
-          if options.key?(:verbose)
-            c.verbose = !!options[:verbose]
+          if (verbose = options[:verbose]) && !verbose.nil?
+            c.verbose = !!verbose
           end
         end
       end

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -44,4 +44,11 @@ context 'Env' do
     env.setup
     assert_equal(false, Resque::Scheduler.dynamic)
   end
+
+  test 'does not override config if it is nil' do
+    Resque::Scheduler.configure { |c| c.dynamic = true }
+    env = new_env(dynamic: nil)
+    env.setup
+    assert_equal(true, Resque::Scheduler.dynamic)
+  end
 end


### PR DESCRIPTION
When I start resque-scheduler for dynamic scheduling, I found the rake task overrides the dynamic setting and disabled it.

I set up resque-scheduler in accordance with the guidance.
https://github.com/resque/resque-scheduler/tree/f0bb556167bd297ef3464e80d6b5b9bde0ab3fdd#rake-integration

Here's the cli setup called after the manual setup.
https://github.com/resque/resque-scheduler/blob/f0bb556167bd297ef3464e80d6b5b9bde0ab3fdd/lib/resque/scheduler/tasks.rb#L17

The cli setup makes hash of all the keys with nil if I don't set it by environment variables.
https://github.com/resque/resque-scheduler/blob/f0bb556167bd297ef3464e80d6b5b9bde0ab3fdd/lib/resque/scheduler/cli.rb#L139

I think we should skip overriding if the value is nil.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resque/resque-scheduler/474)
<!-- Reviewable:end -->
