### PR TITLE
Avoid making keys for nil environment vairables

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,3 +14,5 @@ Style/DoubleNegation:
   Enabled: false
 Metrics/PerceivedComplexity:
   Enabled: false
+Metrics/ClassLength:
+  Max: 110

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -20,6 +20,7 @@ Resque Scheduler authors
 - David Doan
 - David Yang
 - Denis Yagofarov
+- dtaniwaki
 - Evan Tahler
 - Eugene Batogov
 - Giovanni Cappellotto

--- a/lib/resque/scheduler/cli.rb
+++ b/lib/resque/scheduler/cli.rb
@@ -136,7 +136,9 @@ module Resque
 
       def options
         @options ||= {}.tap do |o|
-          CLI_OPTIONS_ENV_MAPPING.map { |key, envvar| o[key] = env[envvar] }
+          CLI_OPTIONS_ENV_MAPPING.each do |key, envvar|
+            o[key] = env[envvar] if env.include?(envvar)
+          end
         end
       end
     end

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -223,4 +223,9 @@ context 'Cli' do
     Resque::Scheduler.expects(:run)
     Resque::Scheduler::Cli.run!([], {})
   end
+
+  test 'does not create keys for unspecified environment variables' do
+    cli = new_cli([], 'DYNAMIC_SCHEDULE' => 'true')
+    assert_equal({ dynamic: 'true' }, cli.send(:options))
+  end
 end


### PR DESCRIPTION
Moved from https://github.com/resque/resque-scheduler/pull/474

The cli's setup env options has keys for nil values which unset all the configs even after initializer or rake tasks's setup set them.

Could you consider to fix this issue?

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/resque/resque-scheduler/475)
<!-- Reviewable:end -->
