### PR TITLE
Make sure Rails module responds to :env method

### DIFF
--- a/lib/resque/scheduler/configuration.rb
+++ b/lib/resque/scheduler/configuration.rb
@@ -13,7 +13,7 @@ module Resque
 
       def env
         return @env if @env
-        @env ||= Rails.env if defined?(Rails)
+        @env ||= Rails.env if defined?(Rails) && Rails.respond_to?(:env)
         @env ||= ENV['RAILS_ENV']
         @env
       end


### PR DESCRIPTION
Some parts of Rails—such as ActionMailer—will initialize the Rails module without `env` and this line will blow up.

Fixes issue #477.

