### PR TITLE
Respect Resque.inline on delayed job removal

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -66,6 +66,7 @@ Resque Scheduler authors
 - Vladislav Shub
 - V Sreekanth
 - Warren Sangster
+- Yuri Kasperovich
 - andreas
 - bbauer
 - camol

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -210,6 +210,8 @@ module Resque
       # O(N) where N is the number of jobs scheduled to fire at the given
       # timestamp
       def remove_delayed_job_from_timestamp(timestamp, klass, *args)
+        return 0 if Resque.inline?
+
         key = "delayed:#{timestamp.to_i}"
         encoded_job = encode(job_to_hash(klass, args))
 
@@ -264,6 +266,8 @@ module Resque
       end
 
       def remove_delayed_job(encoded_job)
+        return 0 if Resque.inline?
+
         timestamps = redis.smembers("timestamps:#{encoded_job}")
 
         replies = redis.pipelined do

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -335,6 +335,20 @@ context 'DelayedQueue' do
     assert_equal(0, Resque.redis.scard("timestamps:#{encoded_job}"))
   end
 
+  test "when Resque.inline = true, remove_delayed doesn't remove the job" \
+       'and returns 0' do
+    begin
+      Resque.inline = true
+
+      timestamp = Time.now + 120
+      Resque.enqueue_at(timestamp, SomeIvarJob, 'foo', 'bar')
+
+      assert_equal(0, Resque.remove_delayed(SomeIvarJob))
+    ensure
+      Resque.inline = false
+    end
+  end
+
   test 'scheduled_at returns an array containing job schedule time' do
     t = Time.now + 120
     Resque.enqueue_at(t, SomeIvarJob)
@@ -817,6 +831,20 @@ context 'DelayedQueue' do
     )
     assert_equal 1, Resque.delayed_timestamp_size(t1)
     assert_equal 0, Resque.delayed_timestamp_size(t2)
+  end
+
+  test 'when Resque.inline = true, remove_delayed_job_from_timestamp' \
+       "doesn't remove any jobs and returns 0" do
+    begin
+      Resque.inline = true
+
+      timestamp = Time.now + 120
+      Resque.enqueue_at(timestamp, SomeIvarJob, 'foo', 'bar')
+
+      assert_equal(0, Resque.delayed_timestamp_size(timestamp))
+    ensure
+      Resque.inline = false
+    end
   end
 
   test 'remove_delayed_job_from_timestamp removes nothing if there ' \


### PR DESCRIPTION
It makes no sense to remove delayed jobs, since there are no queued jobs if Resque.inline is true.
Also, it brakes specs with "Error connecting to Redis" error.