### PR TITLE
Queue button doesn't work bug fixed

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -178,6 +178,17 @@ module Resque
         end
       end
 
+      def enqueue_next_item(timestamp)
+        item = Resque.next_item_for_timestamp(timestamp)
+
+        if item
+          log "queuing #{item['class']} [delayed]"
+          handle_errors { enqueue_from_config(item) }
+        end
+
+        item
+      end
+
       # Enqueues all delayed jobs for a timestamp
       def enqueue_delayed_items_for_timestamp(timestamp)
         item = nil
@@ -185,11 +196,7 @@ module Resque
           handle_shutdown do
             # Continually check that it is still the master
             if master?
-              item = Resque.next_item_for_timestamp(timestamp)
-              if item
-                log "queuing #{item['class']} [delayed]"
-                handle_errors { enqueue_from_config(item) }
-              end
+              item = enqueue_next_item(timestamp)
             end
           end
           # continue processing until there are no more ready items in this

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -107,7 +107,7 @@ module Resque
           formatted_time = Time.at(timestamp).to_default_s
 
           if timestamp > 0
-            unless enqueue_next_item(timestamp)
+            unless Resque::Scheduler.enqueue_next_item(timestamp)
               @error_message = "Unable to remove item at #{formatted_time}"
             end
           else

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -105,9 +105,14 @@ module Resque
         def delayed_queue_now
           timestamp = params['timestamp'].to_i
           if timestamp > 0
-            Resque::Scheduler.enqueue_delayed_items_for_timestamp(timestamp)
+            unless Resque.next_item_for_timestamp(timestamp)
+              @error_message = "Unable to remove item at #{Time.at(timestamp).to_s}"
+            end
+          else
+            @error_message = "Incorrect timestamp #{Time.at(timestamp).to_s}"
           end
-          redirect u('/overview')
+
+          erb scheduler_template('delayed')
         end
 
         def delayed_cancel_now

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -104,12 +104,14 @@ module Resque
 
         def delayed_queue_now
           timestamp = params['timestamp'].to_i
+          formatted_time = Time.at(timestamp).to_default_s
+
           if timestamp > 0
-            unless Resque.next_item_for_timestamp(timestamp)
-              @error_message = "Unable to remove item at #{Time.at(timestamp).to_s}"
+            unless enqueue_next_item(timestamp)
+              @error_message = "Unable to remove item at #{formatted_time}"
             end
           else
-            @error_message = "Incorrect timestamp #{Time.at(timestamp).to_s}"
+            @error_message = "Incorrect timestamp #{formatted_time}"
           end
 
           erb scheduler_template('delayed')

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -104,8 +104,7 @@ module Resque
 
         def delayed_queue_now
           timestamp = params['timestamp'].to_i
-          formatted_time = Time.at(timestamp).to_default_s
-
+          formatted_time = Time.at(timestamp).strftime '%Y-%m-%d %H:%M:%S %z'
           if timestamp > 0
             unless Resque::Scheduler.enqueue_next_item(timestamp)
               @error_message = "Unable to remove item at #{formatted_time}"

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -3,6 +3,10 @@
 
 <%= scheduler_view :search_form, layout: false %>
 
+<p style="font-color: red; font-weight: bold;">
+    <%= @error_message %>
+</p>
+
 <p class='intro'>
   This list below contains the timestamps for scheduled delayed jobs.
   Server local time: <%= Time.now %>

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -265,6 +265,15 @@ context 'DelayedQueue' do
     end
   end
 
+  test 'enqueue_next_item picks one job' do
+    t = Time.now + 60
+
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque.enqueue_at(t, SomeIvarJob)
+    Resque::Scheduler.enqueue_next_item(t)
+    assert_equal(1, Resque.delayed_timestamp_peek(t, 0, 3).length)
+  end
+
   test 'enqueue_delayed_items_for_timestamp creates jobs ' \
        'and empties the delayed queue' do
     t = Time.now + 60

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -256,11 +256,10 @@ context 'on POST to /delayed/clear' do
 end
 
 context 'on POST to /delayed/queue_now' do
-  setup { post '/delayed/queue_now' }
+  setup { post '/delayed/queue_now', timestamp: 0 }
 
-  test 'redirects to overview' do
-    assert last_response.status == 302
-    assert last_response.header['Location'].include? '/overview'
+  test 'returns ok status' do
+    assert last_response.status == 200
   end
 end
 


### PR DESCRIPTION
Fixed contoller method that tried to enqueue task in locked redis environment.
Applies to issue #220 