### PR TITLE
bugfix: NoMethodError: undefined method >' for nil

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -335,7 +335,7 @@ module Resque
 
       def poll_sleep_loop
         @sleeping = true
-        if @poll_sleep_amount > 0
+        if (!(@poll_sleep_amount.nil?) and @poll_sleep_amount > 0)
           start = Time.now
           loop do
             elapsed_sleep = (Time.now - start)

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -335,7 +335,7 @@ module Resque
 
       def poll_sleep_loop
         @sleeping = true
-        if (!(@poll_sleep_amount.nil?) and @poll_sleep_amount > 0)
+        if !(@poll_sleep_amount.nil?) && @poll_sleep_amount > 0
           start = Time.now
           loop do
             elapsed_sleep = (Time.now - start)


### PR DESCRIPTION
When starting the resque-scheduler using rake:

/usr/bin/env nohup /usr/local/rvm/bin/rvm default do bundle exec rake
RAILS_ENV=production
PIDFILE=app/gshared/tmp/pids/scheduler.pid BACKGROUND=yes
VERBOSE=1 MUTE=1 environment resque:scheduler >>
/app-logs/resque.log 2>> /app-logs/resque.log

I got this error, when I have some delayed jobs on the queue:

rake aborted!
NoMethodError: undefined method `>' for nil:NilClass
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:338:in
`poll_sleep_loop'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:328:in
`block in poll_sleep'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:212:in
`handle_shutdown'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:326:in
`poll_sleep'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:62:in
`block in run'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:53:in
`loop'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler.rb:53:in
`run'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler/cli.rb:117:in
`run_forever'
app/gshared/bundle/ruby/2.1.0/bundler/gems/resque-scheduler-90237ff16966/lib/resque/scheduler/tasks.rb:18:in
`block (2 levels) in <top (required)>'
Tasks: TOP => resque:scheduler
(See full trace by running task with --trace)

I didn't get the real problem, I saw on configuration.rb that this
variable should have a default value if I didn't pass anything.

So, I don't know why this variable was nil :/ but this fixes, fix my
problem and I'm doing this PR very fast. If anything is wrong please
tell that I will fix later.