### PR TITLE
Ensure that redis disconnects dont kill the process

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -34,7 +34,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 309
+  Max: 310
 
 # Offense count: 1
 Style/CaseEquality:

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -51,13 +51,14 @@ module Resque
 
           # Now start the scheduling part of the loop.
           loop do
-            if master?
-              begin
+            begin
+              if master?
                 handle_delayed_items
                 update_schedule if dynamic
-              rescue Errno::EAGAIN, Errno::ECONNRESET => e
-                log! e.message
               end
+            rescue Errno::EAGAIN, Errno::ECONNRESET, Redis::CannotConnectError => e
+              log! e.message
+              release_master_lock
             end
             poll_sleep
           end

--- a/lib/resque/scheduler/locking.rb
+++ b/lib/resque/scheduler/locking.rb
@@ -76,6 +76,8 @@ module Resque
 
       def release_master_lock
         master_lock.release
+      rescue Errno::EAGAIN, Errno::ECONNRESET, Redis::CannotConnectError
+        @master_lock = nil
       end
 
       private


### PR DESCRIPTION
This addresses an issue where the scheduler process dies if redis
connectivity is lost. The issue stems from two issues: the begin block
does not include the call to `master?`, which throws the error, and the
connection error is not rescued.

After fixing that issue, a new error occurs when the process tries to
resume scheduling. I addressed this by rescuing connection errors in
`release_master_lock`, unsetting the @master_lock instance variable when
this happens, and explicitly calling `release_master_lock` when the
scheduler cannot connect to redis. There might be a better way to handle
reconnections, happy to address this through a different approach.

Fixes #425

Initial reconnect stacktrace
----------------------------

```
Redis::CannotConnectError: Error connecting to Redis on redis:6379 (Errno::ECONNREFUSED)
/Users/ben/src/resque-scheduler/lib/resque/scheduler/lock/resilient.rb:9:in `acquire!'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/locking.rb:66:in `master?'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:54:in `block in run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/cli.rb:117:in `run_forever'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/tasks.rb:18:in `block (2 levels) in <top (required)>'
Errno::ECONNREFUSED: Connection refused - connect(2) for 192.168.99.100:6379
/Users/ben/src/resque-scheduler/lib/resque/scheduler/lock/resilient.rb:9:in `acquire!'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/locking.rb:66:in `master?'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:54:in `block in run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/cli.rb:117:in `run_forever'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/tasks.rb:18:in `block (2 levels) in <top (required)>'
IO::EINPROGRESSWaitWritable: Operation now in progress - connect(2) would block
/Users/ben/src/resque-scheduler/lib/resque/scheduler/lock/resilient.rb:9:in `acquire!'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/locking.rb:66:in `master?'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:54:in `block in run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/cli.rb:117:in `run_forever'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/tasks.rb:18:in `block (2 levels) in <top (required)>'
Tasks: TOP => resque:scheduler
(See full trace by running task with --trace)
```

Resuming schedule stacktrace
----------------------------

```
Redis::CommandError: NOSCRIPT No matching script. Please use EVAL.
/Users/ben/src/resque-scheduler/lib/resque/scheduler/lock/resilient.rb:9:in `acquire!'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/locking.rb:66:in `master?'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:55:in `block in run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/cli.rb:117:in `run_forever'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/tasks.rb:18:in
`block (2 levels) in <top (required)>'
Tasks: TOP => resque:scheduler
(See full trace by running task with --trace)
```