### PR TITLE
Fixing poll_sleep_amount access bug

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -335,11 +335,11 @@ module Resque
 
       def poll_sleep_loop
         @sleeping = true
-        if @poll_sleep_amount > 0
+        if poll_sleep_amount > 0
           start = Time.now
           loop do
             elapsed_sleep = (Time.now - start)
-            remaining_sleep = @poll_sleep_amount - elapsed_sleep
+            remaining_sleep = poll_sleep_amount - elapsed_sleep
             @do_break = false
             if remaining_sleep <= 0
               @do_break = true


### PR DESCRIPTION
Fixing a `NoMethodError: undefined method `>' for nil:NilClass` error
when starting the scheduler process. The issue is that the
poll_sleep_amount instance variable is nil assigned through the method
with the same name, and should be called through this method to ensure
that a default value can be set.

This addresses the same bug found in https://github.com/resque/resque-scheduler/pull/522.
```
rake aborted!
NoMethodError: undefined method `>' for nil:NilClass
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:341:in `poll_sleep_loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:329:in `block in poll_sleep'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:213:in `handle_shutdown'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:327:in `poll_sleep'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:63:in `block in run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `loop'
/Users/ben/src/resque-scheduler/lib/resque/scheduler.rb:53:in `run'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/cli.rb:117:in `run_forever'
/Users/ben/src/resque-scheduler/lib/resque/scheduler/tasks.rb:18:in `block (2 levels) in <top (required)>'
```