### PR TITLE
Fix race condition in concurrent shutdown/startup

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -361,11 +361,12 @@ module Resque
         handle_signals
         false
       rescue Interrupt
-        if @shutdown
-          Resque.clean_schedules
-          release_master_lock
-        end
+        before_shutdown if @shutdown
         true
+      end
+
+      def before_shutdown
+        release_master_lock
       end
 
       # Sets the shutdown flag, clean schedules and exits if sleeping

--- a/test/multi_process_test.rb
+++ b/test/multi_process_test.rb
@@ -3,9 +3,14 @@ require_relative 'test_helper'
 
 context 'Multi Process' do
   test 'setting schedule= from many process does not corrupt the schedules' do
+    # more info on why we're not using threads:
+    # https://github.com/resque/resque-scheduler/pull/439#discussion_r16788812
+    omit('forking is not supported by jruby but this behaviour' \
+      ' is best tested using forks') if RUBY_ENGINE == 'jruby'
     schedules = {}
-    counts  = []
-    threads = []
+    schedules = {}
+    counts = []
+    pids = []
 
     # This number may need to be increased if this test is not failing
     processes = 20
@@ -17,10 +22,10 @@ context 'Multi Process' do
     end
 
     processes.times do |n|
-      threads << Thread.new do
+      pids << fork_with_marshalled_pipe_and_result do
         sleep n * 0.1
         Resque.schedule = schedules
-        counts << Resque.schedule.size
+        Resque.schedule.size
       end
     end
 
@@ -28,10 +33,91 @@ context 'Multi Process' do
     Resque.schedule = schedules
     counts << Resque.schedule.size
 
-    threads.each(&:join)
+    counts += get_results_from_children(pids)
 
     counts.each_with_index do |c, i|
       assert_equal schedule_count, c, "schedule count is incorrect (c: #{i})"
     end
+  end
+
+  test 'concurrent shutdowns and startups do not corrupt the schedule' do
+    omit('forking is not supported by jruby but this behaviour' \
+      ' is best tested using forks') if RUBY_ENGINE == 'jruby'
+    counts = []
+    children = []
+
+    processes = 40
+
+    schedules = {}
+    schedule_count = 300
+    schedule_count.times do |n|
+      schedules["job_#{n}"] = { 'cron' => '0 1 0 0 0' }
+    end
+
+    Resque.schedule = schedules
+
+    processes.times do |n|
+      children << fork_with_marshalled_pipe_and_result do
+        sleep Random.rand(3) * 0.1
+        if n.even?
+          Resque.schedule = schedules
+          Resque.schedule.size
+        else
+          Resque::Scheduler.before_shutdown
+          nil
+        end
+      end
+    end
+
+    counts += get_results_from_children(children).compact
+
+    counts.each_with_index do |c, i|
+      assert_equal schedule_count, c, "schedule count is incorrect (c: #{i})"
+    end
+  end
+
+  private
+
+  def fork_with_marshalled_pipe_and_result
+    pipe_read, pipe_write = IO.pipe
+    pid = fork do
+      pipe_read.close
+      result = begin
+        [yield, nil]
+      rescue StandardError => exc
+        [nil, exc]
+      end
+      pipe_write.syswrite(Marshal.dump(result))
+      # exit true the process to get around fork issues on minitest 5
+      # see https://github.com/seattlerb/minitest/issues/467
+      Process.exit!(true)
+    end
+    pipe_write.close
+
+    [pid, pipe_read]
+  end
+
+  def get_results_from_children(children)
+    results = []
+    children.each do |pid, pipe|
+      wait_for_child_process_to_terminate(pid)
+
+      fail "forked process failed with #{$CHILD_STATUS}" unless $CHILD_STATUS.success?
+      result, exc = Marshal.load(pipe.read)
+      fail exc if exc
+      results << result
+    end
+    results
+  end
+
+  def wait_for_child_process_to_terminate(pid = -1, timeout = 30)
+    Timeout.timeout(timeout) do
+      Process.wait(pid)
+    end
+  rescue Timeout::Error
+    Process.kill('KILL', pid)
+    # collect status so it doesn't stick around as zombie process
+    Process.wait(pid)
+    flunk 'Child process did not terminate in time.'
   end
 end


### PR DESCRIPTION
This PR addresses issue https://github.com/resque/resque-scheduler/issues/528

Digging through the git history it's not clear why we need to `Resque.clean_schedules` on shutdown since it's done when resque-scheduler starts up. Removing it doesn't fail any tests and fixes the race condition described in #528.

This fix has been monitored in Shopify's environment and it has not been cause of any issues

cc @fw42 @sirupsen