### PR TITLE
Fix error on uninitialized poll sleep amount

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -336,11 +336,11 @@ module Resque
 
       def poll_sleep_loop
         @sleeping = true
-        if @poll_sleep_amount > 0
+        if poll_sleep_amount > 0
           start = Time.now
           loop do
             elapsed_sleep = (Time.now - start)
-            remaining_sleep = @poll_sleep_amount - elapsed_sleep
+            remaining_sleep = poll_sleep_amount - elapsed_sleep
             @do_break = false
             if remaining_sleep <= 0
               @do_break = true

--- a/test/scheduler_task_test.rb
+++ b/test/scheduler_task_test.rb
@@ -38,6 +38,20 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.release_master_lock
   end
 
+  test 'can start successfully' do
+    Resque::Scheduler.poll_sleep_amount = nil
+
+    @pid = Process.pid
+    Thread.new do
+      sleep(0.15)
+      Process.kill(:TERM, @pid)
+    end
+
+    assert_raises SystemExit do
+      Resque::Scheduler.run
+    end
+  end
+
   test 'sending TERM to scheduler breaks out when poll_sleep_amount = 0' do
     Resque::Scheduler.poll_sleep_amount = 0
     Resque::Scheduler.expects(:release_master_lock)


### PR DESCRIPTION
**Problem:** latest master cannot run without specifying the `RESQUE_SCHEDULER_INTERVAL` environment variable

**Solution:** we lazily load `@poll_sleep_amount`; so we should not access it directly

Added a unit test that would fail without the fix.

@fw42 @meatballhat 