### PR TITLE
Resque::Scheduler.logger should be writable by user

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -24,6 +24,7 @@ module Resque
     class << self
       # the Rufus::Scheduler jobs that are scheduled
       attr_reader :scheduled_jobs
+      attr_writer :logger
 
       # Schedule all jobs and continually look for delayed jobs (never returns)
       def run
@@ -395,8 +396,6 @@ module Resque
       end
 
       private
-
-      attr_writer :logger
 
       def logger
         @logger ||= Resque::Scheduler::LoggerBuilder.new(

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -14,8 +14,10 @@ context 'Resque::Scheduler' do
 
   test 'set custom logger' do
     custom_logger = MonoLogger.new('/dev/null')
-    Resque::Scheduler.send(:logger=, custom_logger)
-    assert_equal(custom_logger, Resque::Scheduler.send(:logger))
+    Resque::Scheduler.logger = custom_logger
+
+    custom_logger.expects(:error).once
+    Resque::Scheduler.log_error('test')
   end
 
   test 'configure block' do

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -31,16 +31,16 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.env = 'production'
     config = {
       'cron' => '* * * * *',
-      'class' => 'SomeRealClass',
+      'class' => 'SomeJobWithResqueHooks',
       'args' => '/tmp'
     }
 
     Resque::Job.expects(:create).with(
-      SomeRealClass.queue, SomeRealClass, '/tmp'
+      SomeJobWithResqueHooks.queue, SomeJobWithResqueHooks, '/tmp'
     )
-    SomeRealClass.expects(:before_delayed_enqueue_example).with('/tmp')
-    SomeRealClass.expects(:before_enqueue_example).with('/tmp')
-    SomeRealClass.expects(:after_enqueue_example).with('/tmp')
+    SomeJobWithResqueHooks.expects(:before_delayed_enqueue_example).with('/tmp')
+    SomeJobWithResqueHooks.expects(:before_enqueue_example).with('/tmp')
+    SomeJobWithResqueHooks.expects(:after_enqueue_example).with('/tmp')
 
     Resque::Scheduler.enqueue_from_config(config)
   end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -89,6 +89,12 @@ class SomeRealClass
   end
 end
 
+class SomeJobWithResqueHooks < SomeRealClass
+  def before_enqueue_example; end
+
+  def after_enqueue_example; end
+end
+
 class JobWithParams
   def self.perform(*args)
     @args = args


### PR DESCRIPTION
I imagine it is a very common use-case to swap out loggers between applications. This PR will let the user choose their own logger as long as they adhere to [`Logger`](http://ruby-doc.org/stdlib-2.3.0/libdoc/logger/rdoc/Logger.html). It also changes the corresponding test so that we're not doing private method dances

@fw42 @Sirupsen @meatballhat @bugant @dylanahsmith I'd appreciate some of your 👀  here