### PR TITLE
Make logger accessible

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -23,10 +23,10 @@ module Resque
     public
 
     class << self
+      attr_writer :logger
+
       # the Rufus::Scheduler jobs that are scheduled
       attr_reader :scheduled_jobs
-
-      attr_writer :logger
 
       # allow user to set an additional failure handler
       attr_writer :failure_handler
@@ -405,8 +405,6 @@ module Resque
         @failure_handler ||= Resque::Scheduler::FailureHandler
       end
 
-      private
-
       def logger
         @logger ||= Resque::Scheduler::LoggerBuilder.new(
           quiet: quiet,
@@ -415,6 +413,8 @@ module Resque
           format: logformat
         ).build
       end
+
+      private
 
       def app_str
         app_name ? "[#{app_name}]" : ''

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -20,6 +20,13 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.log_error('test')
   end
 
+  test 'custom logger is accessible' do
+    custom_logger = MonoLogger.new('/dev/null')
+    Resque::Scheduler.logger = custom_logger
+
+    assert_equal custom_logger, Resque::Scheduler.logger
+  end
+
   test 'configure block' do
     Resque::Scheduler.quiet = false
     Resque::Scheduler.configure do |c|

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -125,7 +125,7 @@ def nullify_logger
     c.quiet = nil
     c.verbose = nil
     c.logfile = nil
-    c.send(:logger=, nil)
+    c.logger = nil
   end
 
   ENV['LOGFILE'] = nil


### PR DESCRIPTION
Now that we have a failure handler/hook, we should allow the user to freely choose how they make a call to the logger. 

Additionally, if the user uses a custom logger by doing the following on initialization
```ruby
Resque::Scheduler.logger = CustomLogging.logger
```
Then they should be able to do the following in their failure hook.
```ruby
Resque::Scheduler.logger.info("msg", custom_param: "test")
```
This PR makes the logger attribute accessible to the user.

@fw42 @Sirupsen @dylanahsmith