### PR TITLE
Fix registering signal keys for Windows.

### DIFF
--- a/lib/resque/scheduler/signal_handling.rb
+++ b/lib/resque/scheduler/signal_handling.rb
@@ -13,7 +13,7 @@ module Resque
       # poll/enqueing to finish (should be almost instant).  In the
       # case of sleeping, exit immediately.
       def register_signal_handlers
-        %w(INT TERM USR1 USR2 QUIT).each do |sig|
+        (Signal.list.keys & %w(INT TERM USR1 USR2 QUIT)).each do |sig|
           trap(sig) do
             signal_queue << sig
             # break sleep in the primary scheduler thread, alowing


### PR DESCRIPTION
Some singals(USR,1 USR2, QUIT) are not exist in Windows.
So when registering signal keys, we need to check system signal list.