### PR TITLE
Escape class name in delayed URI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,11 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- 2.3.1
-- jruby-9.1.2.0
+- 2.1.10
+- 2.2.8
+- 2.3.5
+- 2.4.2
+- jruby-9.1.13.0
 env:
   global:
   - COVERAGE=1
@@ -11,7 +14,7 @@ env:
   - RUBYOPT='-W0'
 matrix:
   allow_failures:
-  - rvm: jruby-9.1.2.0
+  - rvm: jruby-9.1.13.0
 services:
 - redis-server
 deploy:
@@ -22,5 +25,5 @@ deploy:
   on:
     tags: true
     repo: resque/resque-scheduler
-    rvm: 2.3.1
+    rvm: 2.4.2
     all_branches: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,10 @@ matrix:
   - rvm: jruby-9.1.13.0
 services:
 - redis-server
+addons:
+  apt:
+    packages:
+      - redis-server
 deploy:
   provider: rubygems
   api_key:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## [Unreleased]
 ### Changed
+- Add support and testing for ruby 2.4
 - Change log format and file name
 - Drop testing on ruby 1.9.3
 - `Lock::Resilient`: Refresh lua script sha if it does not exist in redis server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 
 ### Fixed
 - Reporting version via `resque-scheduler --version`
+- Class name escaping in `/delayed` view
 
 ## [4.3.0] - 2016-06-26
 ### Added

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -46,7 +46,7 @@
       <td><%= h(show_job_arguments(job['args'])) if job && delayed_timestamp_size == 1 %></td>
       <td>
         <% if job %>
-          <a href="<%=u URI("/delayed/jobs/#{job['class']}?args=" + URI.encode(job['args'].to_json)) %>">All schedules</a>
+          <a href="<%=u URI("/delayed/jobs/#{URI.escape(job['class'])}?args=" + URI.encode(job['args'].to_json)) %>">All schedules</a>
         <% end %>
       </td>
     </tr>

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -101,7 +101,7 @@ context 'on GET to /delayed' do
     test "contains link to all schedules for class #{job['class']}" do
       Resque.enqueue_at(job['t'], job['class'], *job['args'])
       get '/delayed'
-      assert last_response.body =~ %r{/delayed/jobs/#{URI.escape(job['class'].to_s)}}
+      assert !(last_response.body =~ %r{/delayed/jobs/#{URI.escape(job['class'].to_s)}}).nil?
     end
   end
 end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -101,8 +101,7 @@ context 'on GET to /delayed' do
     test "contains link to all schedules for class #{job['class']}" do
       Resque.enqueue_at(job['t'], job['class'], *job['args'])
       get '/delayed'
-      link = "/delayed/jobs/#{URI.escape(job['class'].to_s)}"
-      assert last_response.body =~ %r{#{link}}
+      assert last_response.body =~ %r{/delayed/jobs/#{URI.escape(job['class'].to_s)}}
     end
   end
 end

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -75,9 +75,36 @@ context 'on GET to /schedule with scheduled jobs' do
 end
 
 context 'on GET to /delayed' do
-  setup { get '/delayed' }
+  [
+    {
+      'class' => SomeIvarJob,
+      'args' => %w(foo bar),
+      't' => Time.now + 3600
+    },
+    {
+      'class' => SomeFancyJob,
+      'args' => [],
+      't' => Time.now + 30
+    },
+    {
+      'class' => FakePHPClass,
+      'args' => %w(1 10 100),
+      't' => Time.now + 36_000
+    }
+  ].each do |job|
+    test "is 200 with class #{job['class']}" do
+      Resque.enqueue_at(job['t'], job['class'], *job['args'])
+      get '/delayed'
+      assert last_response.ok?
+    end
 
-  test('is 200') { assert last_response.ok? }
+    test "contains link to all schedules for class #{job['class']}" do
+      Resque.enqueue_at(job['t'], job['class'], *job['args'])
+      get '/delayed'
+      link = "/delayed/jobs/#{URI.escape(job['class'].to_s)}"
+      assert last_response.body =~ %r{#{link}}
+    end
+  end
 end
 
 context 'on GET to /delayed/jobs/:klass' do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -107,6 +107,14 @@ end
 
 JobWithoutParams = Class.new(JobWithParams)
 
+class FakePHPClass < SomeJob
+  @queue = :'some-other-kinda::queue-maybe'
+
+  def self.to_s
+    'Namespace\\For\\Job\\Class'
+  end
+end
+
 %w(
   APP_NAME
   DYNAMIC_SCHEDULE


### PR DESCRIPTION
to ensure compatibility with class names that may contain URI-unfriendly chars

Closes #455
