### PR TITLE
factor out recurring enqueue block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 314
+  Max: 317
 
 # Offense count: 1
 Style/CaseEquality:

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -141,11 +141,7 @@ module Resque
             args = [args, nil, job: true] if args.is_a?(::String)
 
             job = rufus_scheduler.send(interval_type, *args) do
-              if master?
-                log! "queueing #{config['class']} (#{name})"
-                Resque.last_enqueued_at(name, Time.now.to_s)
-                enqueue(config)
-              end
+              enqueue_recurring(name, config)
             end
             @scheduled_jobs[name] = job
             interval_defined = true
@@ -416,6 +412,14 @@ module Resque
       end
 
       private
+
+      def enqueue_recurring(name, config)
+        if master?
+          log! "queueing #{config['class']} (#{name})"
+          Resque.last_enqueued_at(name, Time.now.to_s)
+          enqueue(config)
+        end
+      end
 
       def app_str
         app_name ? "[#{app_name}]" : ''


### PR DESCRIPTION
## What does this change?
It factors out the block `resque-scheduler` passes to `rufus-scheduler` into a separate method. This PR makes no logic changes.

## Why make the change?
We use thread local state to determine which redis instance to enqueue a job to. `rufus-scheduler` calls this block from within a new thread. This refactor provides a method we can easily monkey patch so that we can set appropriate thread local state after the new thread has been created.

@fw42 @dylanahsmith 
cc: @Sirupsen 