### PR TITLE
Migration task

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -35,6 +35,7 @@ Resque Scheduler authors
 - Jonathan Conley
 - Jonathan Hyman
 - Jonathan Owens
+- Josh Cronemeyer
 - Joshua Szmajda
 - Justin Weiss
 - Les Hill

--- a/README.md
+++ b/README.md
@@ -640,7 +640,9 @@ on a dedicated Redis database.  While making and managing scheduled tasks,
 `resque-scheduler` currently scans the entire Redis keyspace, which may cause
 latency and stability issues if `resque-scheduler` is hosted on a Redis instance
 storing a large number of keys (such as those written by a different system
-hosted on the same Redis instance).
+hosted on the same Redis instance). The resque:migrate_scheduler rake task is
+provided to move scheduled jobs to a new redis instance when changing your
+application's redis configuration.
 
 #### Compatibility Notes
 

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -6,6 +6,7 @@ require_relative 'scheduler/locking'
 require_relative 'scheduler/logger_builder'
 require_relative 'scheduler/signal_handling'
 require_relative 'scheduler/failure_handler'
+require_relative 'scheduler/scheduled_job_migrator'
 
 module Resque
   module Scheduler

--- a/lib/resque/scheduler/scheduled_job_migrator.rb
+++ b/lib/resque/scheduler/scheduled_job_migrator.rb
@@ -1,0 +1,41 @@
+
+module Resque
+  module Scheduler
+    class ScheduledJobMigrator
+      def initialize(from_redis_url, to_redis_url)
+        @from_redis_url = from_redis_url
+        @to_redis_url = to_redis_url
+      end
+
+      def migrate!
+        migrate_jobs(jobs_to_migrate)
+      end
+
+      private
+
+      def jobs_to_migrate
+        Resque.redis = @from_redis_url
+
+        number_of_timestamps = Resque.delayed_queue_schedule_size
+        return [] if number_of_timestamps < 1
+        Resque.delayed_queue_peek(0, number_of_timestamps).map do |timestamp|
+          number_of_jobs = Resque.delayed_timestamp_size(timestamp)
+          Resque.delayed_timestamp_peek(timestamp, 0, number_of_jobs).map do |job|
+            job['timestamp'] = timestamp # add timestamp to the job hash
+            job
+          end
+        end.flatten!
+      end
+
+      def migrate_jobs(jobs_to_migrate)
+        Resque.redis = @to_redis_url
+
+        jobs_to_migrate.each do |job_hash|
+          Resque.enqueue_at(job_hash['timestamp'],
+                            Util.constantize(job_hash['class']),
+                            *job_hash['args'])
+        end
+      end
+    end
+  end
+end

--- a/lib/resque/scheduler/scheduled_job_migrator.rb
+++ b/lib/resque/scheduler/scheduled_job_migrator.rb
@@ -35,15 +35,15 @@ module Resque
       end
 
       def migrate_jobs(timestamps_jobs_hash)
-        timestamps_jobs_hash.each do |timestamp, jobs|
-          key = "delayed:#{timestamp}"
-          Resque.redis.pipelined do
+        Resque.redis.pipelined do
+          timestamps_jobs_hash.each do |timestamp, jobs|
+            key = "delayed:#{timestamp}"
             jobs.each do |job|
               Resque.redis.sadd("timestamps:#{job}", key)
               Resque.redis.rpush(key, job)
             end
+            Resque.redis.zadd('delayed_queue_schedule', timestamp, timestamp)
           end
-          Resque.redis.zadd('delayed_queue_schedule', timestamp, timestamp)
         end
       end
     end

--- a/lib/resque/scheduler/scheduled_job_migrator.rb
+++ b/lib/resque/scheduler/scheduled_job_migrator.rb
@@ -31,7 +31,7 @@ module Resque
             jobs_by_timestamp[timestamp] = Resque.redis.lrange(key, 0, -1)
           end
         end
-        jobs_by_timestamp.each{ |timestamp, jobs| jobs_by_timestamp[timestamp] = jobs.value }
+        jobs_by_timestamp.each { |timestamp, jobs| jobs_by_timestamp[timestamp] = jobs.value }
       end
 
       def migrate_jobs(timestamps_jobs_hash)

--- a/lib/resque/scheduler/scheduled_job_migrator.rb
+++ b/lib/resque/scheduler/scheduled_job_migrator.rb
@@ -8,7 +8,11 @@ module Resque
       end
 
       def migrate!
-        migrate_jobs(jobs_to_migrate)
+        start_time = Time.now
+        jobs = jobs_to_migrate
+        puts "Migrating #{jobs.count} scheduled jobs."
+        migrate_jobs(jobs)
+        puts "Finished migrating in #{Time.now - start_time} seconds."
       end
 
       private

--- a/lib/resque/scheduler/tasks.rb
+++ b/lib/resque/scheduler/tasks.rb
@@ -25,6 +25,7 @@ namespace :resque do
 
   desc 'A maintenance task for migrating scheduler tasks from one redis DB to another.'
   task :migrate_scheduler, [:from_redis, :to_redis] do |_t, args|
+    Rake::Task["environment"].invoke if Rake::Task["environment"]
     from_redis = args[:from_redis]
     to_redis = args[:to_redis]
     message = 'Missing URL. Usage: rake resque:migrate_scheduler[from_redis_url, to_redis_url]'

--- a/lib/resque/scheduler/tasks.rb
+++ b/lib/resque/scheduler/tasks.rb
@@ -22,4 +22,14 @@ namespace :resque do
     scheduler_cli.parse_options
     Rake::Task['resque:setup'].invoke unless scheduler_cli.pre_setup
   end
+
+  desc 'A maintenance task for migrating scheduler tasks from one redis DB to another.'
+  task :migrate_scheduler, [:from_redis, :to_redis] do |_t, args|
+    from_redis = args[:from_redis]
+    to_redis = args[:to_redis]
+    message = 'Missing URL. Usage: rake resque:migrate_scheduler[from_redis_url, to_redis_url]'
+    raise message unless from_redis && to_redis
+    puts "Migrating scheduled jobs from #{from_redis} to #{to_redis}"
+    Resque::Scheduler::ScheduledJobMigrator.new(from_redis, to_redis).migrate!
+  end
 end

--- a/lib/resque/scheduler/tasks.rb
+++ b/lib/resque/scheduler/tasks.rb
@@ -25,7 +25,7 @@ namespace :resque do
 
   desc 'A maintenance task for migrating scheduler tasks from one redis DB to another.'
   task :migrate_scheduler, [:from_redis, :to_redis] do |_t, args|
-    Rake::Task["environment"].invoke if Rake::Task["environment"]
+    Rake::Task['environment'].invoke if Rake::Task['environment']
     from_redis = args[:from_redis]
     to_redis = args[:to_redis]
     message = 'Missing URL. Usage: rake resque:migrate_scheduler[from_redis_url, to_redis_url]'

--- a/test/scheduled_job_migrator_test.rb
+++ b/test/scheduled_job_migrator_test.rb
@@ -1,0 +1,68 @@
+# vim:fileencoding=utf-8
+
+require_relative 'test_helper'
+
+context 'ScheduledJobMigrator' do
+  setup do
+    Resque::Scheduler.quiet = true
+    Resque.redis.flushall
+    @from_redis = 'localhost:6379:0'
+    @to_redis = 'localhost:6379:1'
+  end
+
+  test 'migrate! moves jobs to other database when jobs are at the same timestamp' do
+    Resque.redis = @from_redis
+
+    t = Time.now + 120
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t, SomeIvarJob, 'foo2')
+
+    migrator = Resque::Scheduler::ScheduledJobMigrator.new(@from_redis, @to_redis)
+    migrator.migrate!
+
+    Resque.redis = @to_redis
+
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+    assert_equal(
+      [
+        { 'args' => ['foo'], 'class' => 'SomeIvarJob', 'queue' => 'ivar' },
+        { 'args' => ['foo2'], 'class' => 'SomeIvarJob', 'queue' => 'ivar' }
+      ], Resque.delayed_timestamp_peek(t, 0, 2)
+    )
+  end
+
+  test 'migrate! will move jobs at various timestamps to the other database' do
+    @from_redis = 'localhost:6379:0'
+    @to_redis = 'localhost:6379:1'
+
+    Resque.redis = @from_redis
+
+    t = Time.now + 120
+    t2 = Time.now + 122
+    Resque.enqueue_at(t, SomeIvarJob, 'foo')
+    Resque.enqueue_at(t2, SomeIvarJob, 'foo2')
+
+    migrator = Resque::Scheduler::ScheduledJobMigrator.new(@from_redis, @to_redis)
+    migrator.migrate!
+
+    Resque.redis = @to_redis
+
+    assert_equal(2, Resque.count_all_scheduled_jobs)
+    assert_equal(
+      [{ 'args' => ['foo'], 'class' => 'SomeIvarJob', 'queue' => 'ivar' }],
+      Resque.delayed_timestamp_peek(t, 0, 1)
+    )
+    assert_equal(
+      [{ 'args' => ['foo2'], 'class' => 'SomeIvarJob', 'queue' => 'ivar' }],
+      Resque.delayed_timestamp_peek(t2, 0, 1)
+    )
+  end
+
+  test 'migrate! works when there are no jobs' do
+    @from_redis = 'localhost:6379:0'
+    @to_redis = 'localhost:6379:1'
+
+    migrator = Resque::Scheduler::ScheduledJobMigrator.new(@from_redis, @to_redis)
+    migrator.migrate!
+  end
+end


### PR DESCRIPTION
Hi there! Thanks for resque-scheduler it's a really useful library! 

I recently migrated resque into a standalone redis DB and I used this rake task to migrate the resque-scheduler jobs. I thought it might be useful to others so I'm making this pull request for your consideration.  Let me know if you think this utility belongs in the codebase.  

If you think it does belong then I'm happy to make changes and improvements. Here are some things I thought we might want to discuss:
- Speed: I chose to use the scheduler API rather than manipulating the underlying redis data to keep the code cleaner and easier to maintain. It migrated 300 jobs on my staging server in about 90 seconds, which is slower than I liked.
- Safety: Current implementation does nothing to protect you if something goes wrong during processing. If the command were to fail in the middle of a migration you'd have to clean up the mess manually (although it leaves the old data intact so you can try again).

Anyway, let me know if you think this utility is something you'd like in your codebase. If so we can discuss the issues above and any others you'd care to consider. I notice that redis has a MIGRATE command http://redis.io/commands/MIGRATE that supports bulk operations and does pipelining and makes some nice guarantees. Probably is the way to go if we care to fix the issues i raised above.

Thanks again!
