### PR TITLE
Add KEEP_PIDFILE option

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,4 +15,4 @@ Style/DoubleNegation:
 Metrics/PerceivedComplexity:
   Enabled: false
 Metrics/ClassLength:
-  Max: 110
+  Max: 120

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -21,6 +21,7 @@ Resque Scheduler authors
 - David Yang
 - Denis Yagofarov
 - dtaniwaki
+- Evan Black
 - Evan Tahler
 - Eugene Batogov
 - Giovanni Cappellotto

--- a/lib/resque/scheduler/cli.rb
+++ b/lib/resque/scheduler/cli.rb
@@ -14,6 +14,7 @@ module Resque
       logformat: 'LOGFORMAT',
       quiet: 'QUIET',
       pidfile: 'PIDFILE',
+      keep_pidfile: 'KEEP_PIDFILE',
       poll_sleep_amount: 'RESQUE_SCHEDULER_INTERVAL',
       verbose: 'VERBOSE'
     }.freeze
@@ -65,6 +66,11 @@ module Resque
         {
           args: ['-P', '--pidfile [PIDFILE]', 'PID file name'],
           callback: ->(options) { ->(p) { options[:pidfile] = p } }
+        },
+        {
+          args: ['-K', '--keep_pidfile',
+                 'Do not delete the pidfile on cleanup [KEEP_PIDFILE]'],
+          callback: ->(options) { ->(k) { options[:keep_pidfile] = k } }
         },
         {
           args: ['-q', '--quiet', 'Run with minimal output [QUIET]'],

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -79,7 +79,7 @@ module Resque
       end
 
       def cleanup_pid_file
-        return unless pidfile_path
+        return unless pidfile_path || options[:keep_pidfile]
 
         File.delete(pidfile_path) if File.exist?(pidfile_path)
         @pidfile_path = nil

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -79,7 +79,7 @@ module Resque
       end
 
       def cleanup_pid_file
-        return unless pidfile_path || options[:keep_pidfile]
+        return if !pidfile_path || options[:keep_pidfile]
 
         File.delete(pidfile_path) if File.exist?(pidfile_path)
         @pidfile_path = nil

--- a/test/cli_test.rb
+++ b/test/cli_test.rb
@@ -84,6 +84,27 @@ context 'Cli' do
     assert_equal('foo', cli.send(:options)[:pidfile])
   end
 
+  test 'defaults to nil keep_pidfile' do
+    assert_equal(nil, new_cli.send(:options)[:keep_pidfile])
+  end
+
+  test 'initializes keep_pidfile from the env' do
+    cli = new_cli([], 'KEEP_PIDFILE' => 'YES')
+    assert_equal('YES', cli.send(:options)[:keep_pidfile])
+  end
+
+  test 'accepts keep_pidfile via -K' do
+    cli = new_cli(%w(-K))
+    cli.parse_options
+    assert_equal(true, cli.send(:options)[:keep_pidfile])
+  end
+
+  test 'accepts keep_pidfile via --pidfile' do
+    cli = new_cli(%w(--keep_pidfile))
+    cli.parse_options
+    assert_equal(true, cli.send(:options)[:keep_pidfile])
+  end
+
   test 'defaults to nil dynamic' do
     assert_equal(nil, new_cli.send(:options)[:dynamic])
   end


### PR DESCRIPTION
This PR is to add a KEEP_PIDFILE option, which will prevent the removal of the pidfile during the cleanup stage. The standard behavior when signaled to quit for Resque seems to be overwriting and not deleting, but I made it an additional option so as not to break any existing user's flow that was dependent on the removal quirk.

I've submitted this because I ran into an issue in deployment with the current version of Resque.
Because of the cleanup delay after sending a QUIT signal to the old scheduler process, it would delete the pidfile of the newly created scheduler process.
In subsequent deploys, this would lead to multiple resque schedulers; with every two deploys resulting in one old, pidfile-less process. I sort of kludged it for a bit using a `pkill -f --signal QUIT resque-scheduler`, but eventually I thought it'd be easy to fix it for my needs and submit it as a PR.

Forgive me if my deployment process is odd, as this may not be necessary in what may be considered a proper deployment procedure. 
I assume that it is necessary to kill and create a new process because if any changes are made to the underlying called codebase, that the old process does not "hot-reload" the newly deployed code. Correct me if this assumption is wrong, I'm partially going off what I've seen in Rake task gists.
