### PR TITLE
Refresh script sha if it doesnt exist on Redis server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 ### Changed
 - Change log format and file name
 - Drop testing on ruby 1.9.3
+- `Lock::Resilient`: Refresh lua script sha if it does not exist in redis server
 
 ### Fixed
 - Reporting version via `resque-scheduler --version`

--- a/lib/resque/scheduler/lock/resilient.rb
+++ b/lib/resque/scheduler/lock/resilient.rb
@@ -32,7 +32,7 @@ module Resque
 
         private
 
-        def evalsha(script, keys:, argv:, refresh: false, final_try: false)
+        def evalsha(script, keys:, argv:, refresh: false)
           sha_method_name = "#{script}_sha"
           Resque.redis.evalsha(
             send(sha_method_name, refresh),
@@ -40,8 +40,9 @@ module Resque
             argv: argv
           )
         rescue Redis::CommandError => e
-          if e.message =~ /NOSCRIPT/ && !final_try
-            evalsha(script, keys: keys, argv: argv, refresh: true, final_try: true)
+          if e.message =~ /NOSCRIPT/
+            refresh = true
+            retry
           else
             raise
           end

--- a/lib/resque/scheduler/lock/resilient.rb
+++ b/lib/resque/scheduler/lock/resilient.rb
@@ -6,19 +6,11 @@ module Resque
     module Lock
       class Resilient < Base
         def acquire!
-          evalsha(
-            :acquire,
-            keys: [key],
-            argv: [value]
-          ).to_i == 1
+          evalsha(:acquire, [key], [value]).to_i == 1
         end
 
         def locked?
-          evalsha(
-            :locked,
-            keys: [key],
-            argv: [value]
-          ).to_i == 1
+          evalsha(:locked, [key], [value]).to_i == 1
         end
 
         def timeout=(seconds)
@@ -32,7 +24,7 @@ module Resque
 
         private
 
-        def evalsha(script, keys:, argv:, refresh: false)
+        def evalsha(script, keys, argv, refresh: false)
           sha_method_name = "#{script}_sha"
           Resque.redis.evalsha(
             send(sha_method_name, refresh),
@@ -43,9 +35,8 @@ module Resque
           if e.message =~ /NOSCRIPT/
             refresh = true
             retry
-          else
-            raise
           end
+          raise
         end
 
         def locked_sha(refresh = false)

--- a/test/scheduler_locking_test.rb
+++ b/test/scheduler_locking_test.rb
@@ -222,6 +222,17 @@ context 'Resque::Scheduler::Lock::Resilient' do
       assert !@lock.locked?, 'you should not have the lock'
     end
 
+    test 'refreshes sha cache when the sha cannot be found on ' \
+         'the redis server' do
+      assert @lock.acquire!
+      assert @lock.locked?
+
+      Resque.redis.script(:flush)
+
+      assert @lock.locked?
+      assert_false @lock.acquire!
+    end
+
     test 'you should not be able to acquire the lock if someone ' \
          'else holds it' do
       lock_is_not_held(@lock)


### PR DESCRIPTION
For the `Resilient` lock, we currently raise `Redis::CommandError` when a lua script disappears in the Redis server for some reason. This can happen when a DBA needs to run [`SCRIPT FLUSH`](http://redis.io/commands/script-flush) or when Redis is wiped before each unit test in a test suite.  

This PR lets resque-scheduler try to re-acquire the sha that was lost.

@Sirupsen @fw42 
cc @wvanbergen @kirs