### PR TITLE
Gracefully shut down rufus scheduler threads

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 317
+  Max: 322
 
 # Offense count: 1
 Style/CaseEquality:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,6 +5,7 @@ environment:
   RUBYOPT: '-W0'
   COVERAGE: 1
   JRUBY_OPTS: ''
+  TZ: 'UTC'
 
 install:
 - set PATH=C:\Ruby23\bin;%PATH%

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -367,7 +367,13 @@ module Resque
         true
       end
 
+      def stop_rufus_scheduler
+        rufus_scheduler.shutdown(:wait)
+        rufus_scheduler.join
+      end
+
       def before_shutdown
+        stop_rufus_scheduler
         release_master_lock
       end
 

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'tzinfo-data'
 
   # We pin rubocop because new cops have a tendency to result in false-y
   # positives for new contributors, which is not a nice experience.


### PR DESCRIPTION
## Problem
Rufus scheduler is used as the engine for the scheduling extension of resque-scheduler (recurring jobs). 

When resque scheduler is instructed to shut down (`INT`/`TERM`), it doesn't gracefully shut down its rufus scheduler threads which can lead to surprising results.

For example, if a job has a `before_enqueue` hook that can take a long time to complete (e.g. talks to a slow consumer), then we can have situations where the hook is ran but the job is never enqueued – because the rufus scheduler threads were terminated while still running `before_enqueue` hooks.

## Solution
Before shutting down resque scheduler:

* Call `rufus_scheduler.shutdown(:wait)` to stop further jobs being scheduled by rufus scheduler and join all the rufus scheduler worker threads
* Call `rufus_scheduler.join` to wait for rufus scheduler to exit before shutting down

---

I've included a test reproducing the issue. The test is `sleep`-dependent. I would rewrite the test if anyone has good suggestions.

@fw42 @pushrax @dylanahsmith @sirupsen @meatballhat