### PR TITLE
Add Resque.remove_delayed_with_queue method

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -4,6 +4,7 @@ Resque Scheduler authors
 - Aaron Suggs
 - Alexander Simonov
 - Andrea Campolonghi
+- Arsen Shamkhalov
 - Ben VandenBos
 - Bernerd Schaefer
 - Bogdan Gusiev

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -151,6 +151,12 @@ module Resque
         end
       end
 
+      # Given an encoded item, remove it from the queue
+      def remove_delayed_with_queue(queue, klass, *args)
+        search = encode(job_to_hash_with_queue(queue, klass, args))
+        remove_delayed_job(search)
+      end
+
       # Given a block, remove jobs that return true from a block
       #
       # This allows for removal of delayed jobs that have arguments matching

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -346,7 +346,7 @@ context 'DelayedQueue' do
 
   test 'remove_delayed_with_queue removes job from given queue and returns the count' do
     t = Time.now + 120
-    another_queue =SomeFancyJob.queue
+    another_queue = SomeFancyJob.queue
 
     encoded_job = Resque.encode(
       class: SomeIvarJob.to_s,

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -344,6 +344,22 @@ context 'DelayedQueue' do
     assert_equal(0, Resque.redis.scard("timestamps:#{encoded_job}"))
   end
 
+  test 'remove_delayed_with_queue removes job from given queue and returns the count' do
+    t = Time.now + 120
+    another_queue =SomeFancyJob.queue
+
+    encoded_job = Resque.encode(
+      class: SomeIvarJob.to_s,
+      args: [],
+      queue: another_queue
+    )
+
+    Resque.enqueue_at_with_queue(another_queue, t, SomeIvarJob)
+
+    assert_equal(1, Resque.remove_delayed_with_queue(another_queue, SomeIvarJob))
+    assert_equal(0, Resque.redis.scard("timestamps:#{encoded_job}"))
+  end
+
   test "when Resque.inline = true, remove_delayed doesn't remove the job" \
        'and returns 0' do
     begin


### PR DESCRIPTION
Currently one cannot remove a job that was queued with `Resque.enque_at_with_queue` method if queue name does not match class's default queue. 