### PR TITLE
Call encode once to remove the possibility of different encoded job values.

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -62,11 +62,13 @@ module Resque
       # if O(log(n)).  Returns true if it's the first job to be scheduled at
       # that time, else false
       def delayed_push(timestamp, item)
+        encoded_job = encode(item)
+
         # First add this item to the list for this timestamp
-        redis.rpush("delayed:#{timestamp.to_i}", encode(item))
+        redis.rpush("delayed:#{timestamp.to_i}", encoded_job)
 
         # Store the timestamps at with this item occurs
-        redis.sadd("timestamps:#{encode(item)}", "delayed:#{timestamp.to_i}")
+        redis.sadd("timestamps:#{encoded_job}", "delayed:#{timestamp.to_i}")
 
         # Now, add this timestamp to the zsets.  The score and the value are
         # the same since we'll be querying by timestamp, and we don't have


### PR DESCRIPTION
This fixes the non cleanup of Resque scheduled sets where the encoded job in the scheduled list and job set were different. In our setup because of the encoded keys being different, there were orphan sets in Redis for which job had already been processed. It led to Redis memory consumption increasing continuously. 

A simple example to reproduce this would be to pass the foo object(from the class described below) as the argument to resque job. 
```
class Foo
  def as_json _options = {}
    {
       generated_at: Time.now.to_f
    }
  end
end

foo = Foo.new
Resque.encode foo
```