### PR TITLE
Use `Resque.enqueue_to` to retain enqueue behaviour

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -33,7 +33,7 @@ module Resque
           if klass.respond_to?(:scheduled)
             klass.scheduled(queue, klass.to_s, *args)
           else
-            Resque::Job.create(queue, klass, *args)
+            Resque.enqueue_to(queue, klass, *args)
           end
         else
           delayed_push(timestamp, job_to_hash_with_queue(queue, klass, args))

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -265,6 +265,26 @@ context 'DelayedQueue' do
     end
   end
 
+  test 'when Resque.inline = true, calls Resque#enqueue ' \
+       'when klass#scheduled is not defined' do
+    old_val = Resque.inline
+    begin
+      Resque.inline = true
+      assert_false(SomeFancyJob.respond_to?(:scheduled))
+      Resque.expects(:enqueue_to).with(:fancy, SomeFancyJob, 'foo', 'bar')
+      Resque.enqueue_at(Time.now + 10, SomeFancyJob, 'foo', 'bar')
+    ensure
+      Resque.inline = old_val
+    end
+  end
+
+  test 'enqueue_at calls Resque#enqueue when given a moment in the past' \
+       'when klass#scheduled is not defined' do
+    assert_false(SomeFancyJob.respond_to?(:scheduled))
+    Resque.expects(:enqueue_to).with(:fancy, SomeFancyJob, 'foo', 'bar')
+    Resque.enqueue_at(Time.now - 10, SomeFancyJob, 'foo', 'bar')
+  end
+
   test 'enqueue_next_item picks one job' do
     t = Time.now + 60
 


### PR DESCRIPTION
If we create the resque job directly, we skip the `before_enqueue` and `after_enqueue` callbacks. This causes surprisingly inconsistent behaviour.

This change mirrors `lib/resque/scheduler.rb:272`.

This ensures consistent behaviour for the follow scenarios: (1) when scheduling something for the future, (2) scheduling something for the future and `Resque.inline == true` (i.e., run it immediately), (3) scheduleing something for the past (i.e., run it immediately).

## Reproduction steps

You can test this out locally by creating a job class that implements `before_enqueue`. For example:

```ruby
class SomeJob
  def self.queue
    :low
  end

  def self.before_enqueue(*args)
    puts "Running before_enqueue"
  end
  
  def self.perform(*args)
    puts "Performing"
  end
end
```

Next, startup a resque process, a resque scheduler process, and a console. Now you can try a few things out to see the inconsistencies in master without this pull request:

```ruby
# Schedule a job for the future
Resque.inline = false
Resque.enqueue_at(Time.now + 10, SomeJob)
# SCHEDULER: Running before_enqueue
# RESQUE: Performing

# Schedule a job for the future running Resque inline
Resque.inline = true
Resque.enqueue_at(Time.now + 10, SomeJob)
# CONSOLE: Perform


# Schedule a job for the future running Resque inline
Resque.inline = false
Resque.enqueue_at(Time.now - 10, SomeJob)
# RESQUE: Perform
```

The first calls `before_enqueue` while the latter two scenarios don't. This causes unexpected behaviour.