### PR TITLE
Show another example usage of cancelling jobs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,6 +235,17 @@ Resque.remove_delayed_selection { |args| args[0]['account_id'] == current_accoun
 Resque.remove_delayed_selection { |args| args[0]['user_id'] == current_user.id }
 ```
 
+If you need to cancel a delayed job based on some matching arguments AND by which class the job is, but don't wish to specify each argument from when the job was created, you can do like so:
+
+``` ruby
+# after you've enqueued a job like:
+Resque.enqueue_at(5.days.from_now, SendFollowUpEmail, :account_id => current_account.id, :user_id => current_user.id)
+# remove jobs matching just the account and that were of the class SendFollowUpEmail:
+Resque.remove_delayed_selection(SendFollowUpEmail) { |args| args[0]['account_id'] == current_account.id }
+# or remove jobs matching just the user and that were of the class SendFollowUpEmail:
+Resque.remove_delayed_selection(SendFollowUpEmail) { |args| args[0]['user_id'] == current_user.id }
+```
+
 If you need to enqueue immediately a delayed job based on some matching arguments, but don't wish to specify each argument from when the job was created, you can do like so:
 
 ``` ruby


### PR DESCRIPTION
Let users know they can be more specific when canceling jobs based on partial argument matching -- they can specify the class too, not just matching arguments, which might cause unwanted matches where you remove jobs you didn't want, just because some rows in the database had the same ID, for example.