### PR TITLE
redis-rb 4.0 support

### DIFF
--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -54,7 +54,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rubocop', '~> 0.40.0'
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
-  spec.add_runtime_dependency 'redis', '~> 3.3'
+  spec.add_runtime_dependency 'redis', '>= 3.3', '< 5'
   spec.add_runtime_dependency 'resque', '~> 1.26'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end


### PR DESCRIPTION
* Loosen Redis version dep to `>= 3.3, < 5`
* Bump redis-namespace for looser Redis version dep.

No [API breakage](https://github.com/redis/redis-rb/blob/master/CHANGELOG.md#40) to deal with.