### PR TITLE
fix dynamic scheduler Delete button in Schedule tab.

### DIFF
--- a/lib/resque/scheduler/server/views/scheduler.erb
+++ b/lib/resque/scheduler/server/views/scheduler.erb
@@ -32,7 +32,7 @@
 	    <td style="padding-left: 15px;"><%= index+ 1 %>.</td>
       <% if Resque::Scheduler.dynamic %>
         <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
-          <form action="<%= u "/schedule" %>" method="post" style="margin-left: 0">
+          <form action="<%= u "/schedule" %>" method="delete" style="margin-left: 0">
             <input type="hidden" name="job_name" value="<%= h name %>">
             <input type="hidden" name="_method" value="delete">
             <input type="submit" value="Delete">


### PR DESCRIPTION
fix dynamic scheduler Delete button in Schedule tab.
It should call DELETE method which is supported in server, instead of POST.

https://github.com/resque/resque-scheduler/blob/master/lib/resque/scheduler/server.rb#L27