### PR TITLE
fix to set poll_sleep_amount option

### DIFF
--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -70,7 +70,7 @@ module Resque
 
           c.logformat = options[:logformat] if options.key?(:logformat)
 
-          if psleep = options[:poll_sleep_amount] && !psleep.nil?
+          if (psleep = options[:poll_sleep_amount]) && !psleep.nil?
             c.poll_sleep_amount = Float(psleep)
           end
 


### PR DESCRIPTION
I can't set `poll_sleep_amount` when execute `exe/resque-scheduler --interval 0.1`. 1d339567
cause is 👇

```ruby
    # lib/resque/scheduler/env.rb
    61: def setup_scheduler_configuration
    62:   Resque::Scheduler.configure do |c|
    63:     c.app_name = options[:app_name] if options.key?(:app_name)
    64:
    65:     c.dynamic = !!options[:dynamic] if options.key?(:dynamic)
    66:
    67:     c.env = options[:env] if options.key(:env)
    68:
    69:     c.logfile = options[:logfile] if options.key?(:logfile)
    70:
    71:     c.logformat = options[:logformat] if options.key?(:logformat)
    72:     binding.pry
    73:
 => 74:     if psleep = options[:poll_sleep_amount] && !psleep.nil?
    75:       c.poll_sleep_amount = Float(psleep) # didn't execute...
    76:     end
    77:
    78:     c.verbose = !!options[:verbose] if options.key?(:verbose)
    79:   end
    80: end

[1] pry(#<Resque::Scheduler::Env>)> options[:poll_sleep_amount]
=> "0.1"
[2] pry(#<Resque::Scheduler::Env>)> psleep = options[:poll_sleep_amount] && !psleep.nil?
=> false
[3] pry(#<Resque::Scheduler::Env>)> psleep
=> false
[6] pry(#<Resque::Scheduler::Env>)> (psleep = options[:poll_sleep_amount]) && !psleep.nil?
=> true
[7] pry(#<Resque::Scheduler::Env>)> psleep
=> "0.1"
```

thanks.