### PR TITLE
Delay an existing job or schedule a new job

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -10,6 +10,7 @@ Resque Scheduler authors
 - Brian Landau
 - Brian P O'Rourke
 - Carlos Antonio da Silva
+- Chris Bisnett
 - Chris Kampmeier
 - DJ Hartman
 - Damon P. Cortesi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## [Unreleased]
 ### Changed
 - Remove support for Ruby < 2.3
+- Add `delay_or_enqueue_at` for delaying existing jobs or creating a new job
 
 ## [4.5.0] - 2021-09-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ since the jobs are stored in a redis sorted set (zset).  I can't imagine this
 being an issue for someone since redis is stupidly fast even at log(n), but full
 disclosure is always best.
 
-#### Removing Delayed jobs
+#### Removing Delayed Jobs
 
 If you have the need to cancel a delayed job, you can do like so:
 
@@ -254,6 +254,47 @@ Resque.enqueue_delayed_selection { |args| args[0]['account_id'] == current_accou
 # or enqueue immediately jobs matching just the user:
 Resque.enqueue_delayed_selection { |args| args[0]['user_id'] == current_user.id }
 ```
+
+#### Updating Delayed Jobs
+
+Previously delayed jobs may be delayed even further into the future like so:
+
+```ruby
+# after you've enqueued a job like:
+Resque.enqueue_at(1.minute.from_now, SendNotifications, :user_id => current_user.id)
+# delay running the job until two minutes from now
+Resque.delay_or_enqueue_at(2.minutes.from_now, SendNotifications, :user_id => current_user.id)
+```
+
+You don't need to worry if a matching job has already been queued, because if no matching jobs are found a new job is created and enqueued as if you had called `enqueue_at`. This means you don't need any special conditionals to know if a job has already been queued. You simply create the job like so:
+
+```ruby
+Resque.delay_or_enqueue_at(1.minute.from_now, SendNotifications, :user_id => current_user.id)
+```
+
+If multiple matching jobs are found, all of the matching jobs will be updated to have the same timestamp even if their original timestamps were not the same.
+
+```ruby
+# enqueue multiple jobs with different delay timestamps
+Resque.enqueue_at(1.minute.from_now, SendNotifications, :user_id => current_user.id)
+Resque.enqueue_at(2.minutes.from_now, SendNotifications, :user_id => current_user.id)
+
+# delay running the two jobs until 5 minutes from now
+Resque.delay_or_enqueue_at(5.minutes.from_now, SendNotifications, :user_id => current_user.id)
+```
+
+The most useful case for increasing the delay of an already delayed job is to batch together work based on multiple events. For example, if you wanted to send a notification email to a user when an event triggers but didn't want to send 10 emails if many events happened within a short period, you could use this technique to delay the noficication email until no events have triggered for a period of time. This way you could send 1 email containing the 10 notifications once no events have triggered for 2 minutes. You could implement this like so:
+
+```ruby
+# Send a notification when an event is created.
+# app/models/event.rb
+after_commit on: :create do
+  Resque.delay_or_enqueue_in(2.minutes, SendNotifications, :user_id => user.id)
+end
+```
+
+When the first event is created a job will be scheduled to send unsent notifications to the associated user. If another event is created within the 2 minute window, the timer will be reset to 2 minutes. This will continue as long as new events are created for the specific user before the 2 minute timer expires. Once the timer expires and the job is scheduled any new events that are created will schedule a new job and start the process over. By adjusting the window you can tweak the trade-off between sending notification emails quickly after an event happens and sending fewer emails.
+
 
 ### Scheduled Jobs (Recurring Jobs)
 

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -63,6 +63,24 @@ module Resque
                               klass, *args)
       end
 
+      # Update the delayed timestamp of any matching delayed jobs or enqueue a
+      # new job if no matching jobs are found. Returns the number of delayed or
+      # enqueued jobs.
+      def delay_or_enqueue_at(timestamp, klass, *args)
+        count = remove_delayed(klass, *args)
+        count = 1 if count == 0
+
+        count.times do
+          enqueue_at(timestamp, klass, *args)
+        end
+      end
+
+      # Identical to +delay_or_enqueue_at+, except it takes
+      # number_of_seconds_from_now instead of a timestamp
+      def delay_or_enqueue_in(number_of_seconds_from_now, klass, *args)
+        delay_or_enqueue_at(Time.now + number_of_seconds_from_now, klass, *args)
+      end
+
       # Used internally to stuff the item into the schedule sorted list.
       # +timestamp+ can be either in seconds or a datetime object. The
       # insertion time complexity is O(log(n)). Returns true if it's


### PR DESCRIPTION
Add functionality to find previously delayed jobs and update their timestamp or queue a new job if no previously delayed jobs match. This is similar to the `find_or_create_by` functionality of ActiveRecord.

The current implementation doesn't care about the timestamps of the existing jobs and will update all matching jobs to the specified timestamp. This means that some jobs may be delayed further into the future and others may be executed sooner. Example:
```
     Job1                  Job2
------^----------*----------^
            New Timestamp
```

**Background**
Several times I've found myself needing a solution for a batching up some background work. One of the most common patterns is notifying users when some event happens. The most naive solution is to send an email when an event is created. In some situations this is fine, except when several events happen within a short period of time. Users will quickly get annoyed that you're filling their inbox with notification emails. So the obvious step is to batch up the emails and only send a few notification emails containing multiple events.

I've implemented this previously by creating a scheduled job that runs every X minutes and finds all the notifications that haven't been sent, marks them as sent, and sends the notification email. This works OK except it's hard to control the trade-off between sending the notification in a timely manner and not sending too many emails. For example, if the scheduled job is set to run every 10 minutes and an event is created within the first minute, the notification won't be sent for 9 minutes or more. This isn't ideal because the notification took quite a while to be sent. On the other hand if 50 events are created within the 10 minute window then we've saved the user 49 emails.

With this functionality it's really easy to implement a better solution. When an event is created it will either create a new background job or will delay an existing scheduled job. So we can implement a system that will send a notification email within X minutes of the last event. If a bunch of events are created in quick succession the background job's delayed timer will keep getting reset but will still run within X minutes of the last event. This way we can decrease the window and send the notification emails with less of a delay but still avoid sending too many emails when several events trigger in quick succession.