### PR TITLE
Support custom job queus in enqueue_delayed_selection

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -88,6 +88,7 @@ module Resque
       end
 
       # Returns the size of the delayed queue schedule
+      # this does not represent the number of items in the queue to be scheduled
       def delayed_queue_schedule_size
         redis.zcard :delayed_queue_schedule
       end
@@ -149,10 +150,22 @@ module Resque
         remove_delayed_job(search)
       end
 
+      def remove_delayed_in_queue(klass, queue, *args)
+        search = encode(job_to_hash_with_queue(queue, klass, args))
+        remove_delayed_job(search)
+      end
+
       # Given an encoded item, enqueue it now
       def enqueue_delayed(klass, *args)
         hash = job_to_hash(klass, args)
         remove_delayed(klass, *args).times do
+          Resque::Scheduler.enqueue_from_config(hash)
+        end
+      end
+
+      def enqueue_delayed_with_queue(klass, queue, *args)
+        hash = job_to_hash_with_queue(queue, klass, args)
+        remove_delayed_in_queue(klass, queue, *args).times do
           Resque::Scheduler.enqueue_from_config(hash)
         end
       end
@@ -181,7 +194,15 @@ module Resque
         found_jobs.reduce(0) do |sum, encoded_job|
           decoded_job = decode(encoded_job)
           klass = Util.constantize(decoded_job['class'])
-          sum + enqueue_delayed(klass, *decoded_job['args'])
+          queue = decoded_job['queue']
+
+          if queue
+            jobs_queued = enqueue_delayed_with_queue(klass, queue, *decoded_job['args'])
+          else
+            jobs_queued = enqueue_delayed(klass, *decoded_job['args'])
+          end
+
+          jobs_queued + sum
         end
       end
 
@@ -271,6 +292,8 @@ module Resque
         { class: klass.to_s, args: args, queue: queue }
       end
 
+      # Removes a job from the queue, but not modify the timestamp schedule. This method
+      # will not effect the output of `delayed_queue_schedule_size`
       def remove_delayed_job(encoded_job)
         return 0 if Resque.inline?
 
@@ -282,6 +305,9 @@ module Resque
             redis.srem("timestamps:#{encoded_job}", key)
           end
         end
+
+        # timestamp key is not removed from the schedule, this is done later
+        # by the scheduler loop
 
         return 0 if replies.nil? || replies.empty?
         replies.each_slice(2).map(&:first).inject(:+)

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -928,6 +928,18 @@ context 'DelayedQueue' do
     end
   end
 
+  test 'requeues a job in the queue originally specified regardless' \
+       'of the queue attached to the class' do
+    Resque.enqueue_in_with_queue('notivar', 1, SomeIvarJob)
+
+    assert_equal(1, Resque.count_all_scheduled_jobs)
+    assert_equal(1, Resque.enqueue_delayed_selection { true })
+    assert_equal(0, Resque.count_all_scheduled_jobs)
+
+    assert_equal(1, Resque.size('notivar'))
+    assert_equal(0, Resque.size(Resque.queue_from_class(SomeIvarJob)))
+  end
+
   test 'inlining jobs with Resque.inline config' do
     begin
       Resque.inline = true


### PR DESCRIPTION
I discovered this bug while testing some changes to [resque-retry](https://github.com/lantins/resque-retry/pull/149):

* You specify a queue for a job which is different than the default queue for the job class via `Resque.enqueue_in_with_queue` or a related method
* You then manually queue the job using `Resque.enqueue_delayed_selection { true }`
* The job will not be enqueued on the custom queue specified, instead the job's default queue is used

This PR fixes this issue. Let me know what you think and I write up some tests this case!