### PR TITLE
Honour environment specified on command line

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -27,6 +27,7 @@ Resque Scheduler authors
 - Harry Lascelles
 - Henrik Nyh
 - Hormoz Kheradmand
+- Ian Davies
 - James Le Cuirot
 - Jarkko Mönkkönen
 - John Crepezzi

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -64,7 +64,7 @@ module Resque
 
           c.dynamic = !!options[:dynamic] if options.key?(:dynamic)
 
-          c.env = options[:env] if options.key(:env)
+          c.env = options[:env] if options.key?(:env)
 
           c.logfile = options[:logfile] if options.key?(:logfile)
 

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -44,4 +44,18 @@ context 'Env' do
     env.setup
     assert_equal(false, Resque::Scheduler.dynamic)
   end
+
+  test 'keep set environment if no option given' do
+    Resque::Scheduler.configure { |c| c.env = 'development' }
+    env = new_env
+    env.setup
+    assert_equal('development', Resque::Scheduler.env)
+  end
+
+  test 'override environment if option given' do
+    Resque::Scheduler.configure { |c| c.env = 'development' }
+    env = new_env(env: 'test')
+    env.setup
+    assert_equal('test', Resque::Scheduler.env)
+  end
 end


### PR DESCRIPTION
Addresses #653.

The issue was that [lib/resque/scheduler/env.rb:67](https://github.com/resque/resque-scheduler/blob/78c5325e91a8588344e64379021afc7812f7f4bb/lib/resque/scheduler/env.rb#L67) was calling `key` rather than `key?`.  It's a trivial fix which I've included in this PR.

But there are potential implications for backward compatibility for existing usage.
