### PR TITLE
Support resque 2.x.x

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,11 @@ matrix:
   - rvm: jruby-9.1.13.0
 services:
 - redis-server
+before_install:
+  - sudo sed -e 's/^bind.*/bind 127.0.0.1/' /etc/redis/redis.conf > redis.conf
+  - sudo mv redis.conf /etc/redis
+  - sudo service redis-server start
+  - echo PING | nc localhost 6379
 addons:
   apt:
     packages:

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
-  spec.add_runtime_dependency 'resque', '>= 1.26', '< 3.0.0'
+  spec.add_runtime_dependency 'resque', '>= 1.26'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
-  spec.add_runtime_dependency 'resque', '>= 1.26', '<= 2.0.0'
+  spec.add_runtime_dependency 'resque', '>= 1.26', '< 3.0.0'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
-  spec.add_runtime_dependency 'resque', '~> 1.26'
+  spec.add_runtime_dependency 'resque', '>= 1.26', '<= 2.0.0'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end


### PR DESCRIPTION
- Test suite passes locally.  Failed with travis here due to missing REDIS env, not sure why.
- Major version bump upstream resque mainly to drop support for older ruby/rails.  This is okay as resque-scheduler will still be able to use lower versions than resque 2.0.0 provided users have it locked as such.