### PR TITLE
Release 4.4.0 with Resque 2 and redis-rb 4 support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
+## [4.4.0] - 2019-04-11
+### Added
+- Support Resque 2
+- Support redis-rb 4
+- Support Ruby 2.5
+
+### Fixed
+- Redis timeouts no longer crash the scheduler process
+- Fix race condition when running multiple schedulers
+- Fix setting the `poll_sleep_amount` option
+- Escape class names in resque-web /delayed URLs
+
+## Changed
+- Addressed redis-namespace deprecation warnings
+- Ensure `enqueue_in` args are Numeric, catching a common issue passing `ActiveSupport::Duration`
+
 ## [4.3.1] - 2017-11-20
 ### Changed
 - Add support and testing for ruby 2.4
@@ -408,7 +424,8 @@
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/resque/resque-scheduler/compare/v4.3.1...HEAD
+[Unreleased]: https://github.com/resque/resque-scheduler/compare/v4.4.0...HEAD
+[4.4.0]: https://github.com/resque/resque-scheduler/compare/v4.3.1...v4.4.0
 [4.3.1]: https://github.com/resque/resque-scheduler/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/resque/resque-scheduler/compare/v4.2.1...v4.3.0
 [4.2.1]: https://github.com/resque/resque-scheduler/compare/v4.2.0...v4.2.1

--- a/lib/resque/scheduler/version.rb
+++ b/lib/resque/scheduler/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module Scheduler
-    VERSION = '4.3.1'.freeze
+    VERSION = '4.4.0'.freeze
   end
 end


### PR DESCRIPTION
~~Concerned that CI is testing against Resque 2 only, though.~~ #668 