### PR TITLE
Enforce a minimum Resque version of 1.27.0 to avoid crashing on startup.

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -67,6 +67,7 @@ Resque Scheduler authors
 - Tim Liner
 - Tony Lewis
 - Tom Crayford
+- Tsu-Shiuan Lin
 - Vincent Zhu
 - Vladislav Shub
 - V Sreekanth

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -55,6 +55,6 @@ Gem::Specification.new do |spec|
 
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
-  spec.add_runtime_dependency 'resque', '>= 1.26'
+  spec.add_runtime_dependency 'resque', '>= 1.27'
   spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
 end


### PR DESCRIPTION
In the 4.4.0 release, Resque Scheduler can fail on startup in [locking.rb](https://github.com/resque/resque-scheduler/blob/fb68bc49933d009858ac2fd5057761d4056d1f0e/lib/resque/scheduler/locking.rb#L100) if your Resque version is lower than `1.27.0` with 👇 

```
NoMethodError: undefined method `data_store' for Resque:Module
```

The `data_store` class was only introduced into Resque from version `1.27.0` here https://github.com/resque/resque/pull/1466 via [this](https://github.com/resque/resque/commit/4bb44413a045fca78d25e22ad535b3f5ea97fab8#diff-102541f6f2ba476fceb8e45917e63420) commit.

![image](https://user-images.githubusercontent.com/16593552/56803624-72c26f80-6823-11e9-9910-a3d8aeff7242.png)
