### PR TITLE
Require redis errors to get standalone working

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -1,5 +1,6 @@
 # vim:fileencoding=utf-8
 
+require 'redis/errors'
 require 'rufus/scheduler'
 require_relative 'scheduler/configuration'
 require_relative 'scheduler/locking'


### PR DESCRIPTION
Running resque-scheduler by itself currently raises this error because redis is not available:

```
resque-scheduler-4.4.0/lib/resque/scheduler.rb:17:in `<module:Scheduler>': uninitialized constant Resque::Scheduler::Redis (NameError)
```

This fixes it. Ref this issue -> https://github.com/resque/resque-scheduler/issues/665