### PR TITLE
Fixing spelling error of rails_env

### DIFF
--- a/lib/resque/scheduler/scheduling_extensions.rb
+++ b/lib/resque/scheduler/scheduling_extensions.rb
@@ -36,7 +36,7 @@ module Resque
       # :args can be any yaml which will be converted to a ruby literal and
       # passed in a params. (optional)
       #
-      # :rails_envs is the list of envs where the job gets loaded. Envs are
+      # :rails_env is the list of envs where the job gets loaded. Envs are
       # comma separated (optional)
       #
       # :description is just that, a description of the job (optional). If


### PR DESCRIPTION
The code[1] uses "rails_env" as the name of the key. This bit of documentation had it listed as "rails_envs".

[1] https://github.com/resque/resque-scheduler/blob/master/lib/resque/scheduler.rb#L140