### PR TITLE
Add reload flag to Resque.remove_schedule

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -30,6 +30,7 @@ Resque Scheduler authors
 - Ian Davies
 - James Le Cuirot
 - Jarkko Mönkkönen
+- Jimmy Chao
 - John Crepezzi
 - John Griffin
 - Jon Larkowski and Les Hill

--- a/lib/resque/scheduler/scheduling_extensions.rb
+++ b/lib/resque/scheduler/scheduling_extensions.rb
@@ -101,12 +101,13 @@ module Resque
       end
 
       # remove a given schedule by name
-      def remove_schedule(name)
+      # Preventing a reload is optional and available to batch operations
+      def remove_schedule(name, reload = true)
         non_persistent_schedules.delete(name)
         redis.hdel(:persistent_schedules, name)
         redis.sadd(:schedules_changed, name)
 
-        reload_schedule!
+        reload_schedule! if reload
       end
 
       private


### PR DESCRIPTION
Hello,

I am working on a dynamic environment setting which remove redundant jobs by batch, so I mimic what `Resque.set_schedule` method did, add a flag to not reload until the end. Also add a test to cover this case.

Let me know how you think about this feature and any feedback or changes required.