### PR TITLE
Add a script to check that 'bundle console' succeeds to the CI build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,6 +32,9 @@ before_install:
   - sudo mv redis.conf /etc/redis
   - sudo service redis-server start
   - echo PING | nc localhost 6379
+script:
+  - rake
+  - bin/bundle_console_test.sh
 addons:
   apt:
     packages:

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ before_install:
   - sudo service redis-server start
   - echo PING | nc localhost 6379
 script:
-  - rake
+  - bundle exec rake
   - bin/bundle_console_test.sh
 addons:
   apt:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,3 +24,4 @@ before_test:
 
 test_script:
 - bundle exec rake
+- bin\bundle_console_test.bat

--- a/bin/bundle_console_test.bat
+++ b/bin/bundle_console_test.bat
@@ -1,0 +1,10 @@
+ECHO off
+
+ECHO "exit" | bundle console > null
+
+if %errorlevel% == 0 (
+  ECHO "bundle console succeeded"
+) ELSE (
+  ECHO "bundle console failed"
+  exit 1
+)

--- a/bin/bundle_console_test.sh
+++ b/bin/bundle_console_test.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+if echo "exit" | bundle console > /dev/null ; then
+  echo 'bundle console succeeded'
+else
+  echo 'bundle console failed'
+  exit 1
+fi


### PR DESCRIPTION
# Problem

We were updating dependencies in our Rails app and discovered that updating to Resque Scheduler v4.4.0 caused our builds to fail with the following error:

```
NameError: uninitialized constant Resque::Scheduler::Redis
```

# Solution

It looks like the problem was fixed in [this commit](https://github.com/resque/resque-scheduler/commit/f6603dc813cda86cc28b4eab08b69c524fdc0781) (thank you!); however, I am proposing an additional CI build step that will attempt to load the gem and all of its dependencies via `bundle console`.  I ran `bundle console` with v4.4.0 and saw the following backtrace:

```
NameError: uninitialized constant Resque::Scheduler::Redis
  /Users/joellubrano/Projects/resque-scheduler/lib/resque/scheduler.rb:18:in `<module:Scheduler>'
  /Users/joellubrano/Projects/resque-scheduler/lib/resque/scheduler.rb:12:in `<module:Resque>'
  /Users/joellubrano/Projects/resque-scheduler/lib/resque/scheduler.rb:11:in `<top (required)>'
  /Users/joellubrano/Projects/resque-scheduler/lib/resque-scheduler.rb:2:in `require_relative'
  /Users/joellubrano/Projects/resque-scheduler/lib/resque-scheduler.rb:2:in `<top (required)>'
  /Users/joellubrano/.rvm/gems/ruby-head/gems/bundler-1.17.2/lib/bundler/runtime.rb:81:in `require'
```

Running `bundle console` on the `master` branch succeeds as expected.

Overall, my goal is to automate some sort of verification that the gem will load all of its dependencies in an application-like environment.  Additional dependencies are required before the test suite executes, so I am not sure if the test suite alone suffices for this type of verification.  Perhaps the test suite could be modified, but this seemed like a simpler approach potentially.