### PR TITLE
Ensure that jobs are directly created for jobs enqueued at Time.now

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -24,7 +24,7 @@ module Resque
       def enqueue_at_with_queue(queue, timestamp, klass, *args)
         return false unless plugin.run_before_schedule_hooks(klass, *args)
 
-        if Resque.inline? || timestamp.to_i < Time.now.to_i
+        if Resque.inline? || timestamp.to_i <= Time.now.to_i
           # Just create the job and let resque perform it right away with
           # inline.  If the class is a custom job class, call self#scheduled
           # on it. This allows you to do things like

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'test-unit'
   spec.add_development_dependency 'yard'
   spec.add_development_dependency 'tzinfo-data'
+  spec.add_development_dependency 'timecop'
 
   # We pin rubocop because new cops have a tendency to result in false-y
   # positives for new contributors, which is not a nice experience.

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -285,6 +285,13 @@ context 'DelayedQueue' do
     Resque.enqueue_at(Time.now - 10, SomeFancyJob, 'foo', 'bar')
   end
 
+  test 'enqueue_at calls Resque#enqueue when given the current time' do
+    Timecop.freeze do
+      Resque.expects(:enqueue_to).with(:fancy, SomeFancyJob, 'foo', 'bar')
+      Resque.enqueue_at(Time.now, SomeFancyJob, 'foo', 'bar')
+    end
+  end
+
   test 'enqueue_next_item picks one job' do
     t = Time.now + 60
 

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -5,7 +5,7 @@ context 'scheduling jobs with hooks' do
   setup { Resque.data_store.redis.flushall }
 
   test 'before_schedule hook that does not return false should be enqueued' do
-    enqueue_time = Time.now
+    enqueue_time = Time.now + 1
     SomeRealClass.expects(:before_schedule_example).with(:foo)
     SomeRealClass.expects(:after_schedule_example).with(:foo)
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)
@@ -14,7 +14,7 @@ context 'scheduling jobs with hooks' do
   end
 
   test 'before_schedule hook that returns false should not be enqueued' do
-    enqueue_time = Time.now
+    enqueue_time = Time.now + 1
     SomeRealClass.expects(:before_schedule_example).with(:foo).returns(false)
     SomeRealClass.expects(:after_schedule_example).never
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -6,6 +6,7 @@ require 'minitest'
 require 'mocha/setup'
 require 'rack/test'
 require 'resque'
+require 'timecop'
 
 $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
 require 'resque-scheduler'


### PR DESCRIPTION
# Problem

If less than a second passes between calling `Resque.enqueue_in(0, ...)`, which is not all that unlikely, a job may be delayed when we don't expect the job to be delayed.  In high traffic applications where the Resque Scheduler process is very busy, this unexpected delay can grow as other jobs are being enqueued after their own delays.  Since Resque Scheduler only supports multiple instances for redundancy, there is no way to scale Resque Scheduler horizontally.  Thus my goal is to ensure that as many jobs as possible are created directly and not unexpectedly delayed.

# Solution

Use a `<=` comparison with `Time.now` to determine whether or not to delay enqueuing/creating a Resque job.  For what it's worth, this PR is reminiscent of https://github.com/resque/resque-scheduler/pull/226, but I want to use `<=` rather than `<` for the `Time.now` comparison.