### PR TITLE
add a railtie to load rescue scheduler with defaults

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -8,6 +8,8 @@ require_relative 'scheduler/logger_builder'
 require_relative 'scheduler/signal_handling'
 require_relative 'scheduler/failure_handler'
 
+require 'resque/scheduler/railtie' if defined?(Rails)
+
 module Resque
   module Scheduler
     autoload :Cli, 'resque/scheduler/cli'

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -278,6 +278,8 @@ module Resque
             # CustomJobClass). Otherwise, pass off to Resque.
             if klass.respond_to?(:scheduled)
               klass.scheduled(queue, klass_name, *params)
+            elsif klass.respond_to?(:perform_later)
+              klass.set(queue: queue).perform_later(*params)
             else
               Resque.enqueue_to(queue, klass, *params)
             end

--- a/lib/resque/scheduler/railtie.rb
+++ b/lib/resque/scheduler/railtie.rb
@@ -1,0 +1,15 @@
+require 'resque/scheduler/server'
+
+module Resque
+  class Railtie < Rails::Railtie
+    rake_tasks do
+      require 'resque/scheduler/tasks'
+    end
+
+    initializer 'resque-scheulder.railtie.initializer' do
+      Resque.schedule = YAML.load_file('config/resque_schedule.yml')
+    end
+  end
+end
+
+

--- a/lib/resque/scheduler/railtie.rb
+++ b/lib/resque/scheduler/railtie.rb
@@ -5,10 +5,6 @@ module Resque
     rake_tasks do
       require 'resque/scheduler/tasks'
     end
-
-    initializer 'resque-scheulder.railtie.initializer' do
-      Resque.schedule = YAML.load_file('config/resque_schedule.yml')
-    end
   end
 end
 

--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -49,7 +49,7 @@ module Resque
             erb scheduler_template('requeue-params')
           else
             Resque::Scheduler.enqueue_from_config(config)
-            redirect u('/overview')
+            redirect u('/schedule')
           end
         end
 
@@ -69,7 +69,7 @@ module Resque
           # Insert the args hash into config and queue the resque job
           config = config.merge('args' => config_args)
           Resque::Scheduler.enqueue_from_config(config)
-          redirect u('/overview')
+          redirect u('/schedule')
         end
 
         def delete_schedule

--- a/lib/resque/scheduler/server/views/scheduler.erb
+++ b/lib/resque/scheduler/server/views/scheduler.erb
@@ -29,7 +29,7 @@
   <% Resque.schedule.keys.sort.each_with_index do |name, index| %>
     <% config = Resque.schedule[name] %>
     <tr style="<%= scheduled_in_this_env?(name) ? '' : 'color: #9F6000;background: #FEEFB3;' %>">
-	    <td style="padding-left: 15px;"><%= index+ 1 %>.</td>
+      <td style="padding-left: 15px;"><%= index+ 1 %>.</td>
       <% if Resque::Scheduler.dynamic %>
         <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
           <form action="<%= u "/schedule" %>" method="post" style="margin-left: 0">


### PR DESCRIPTION
Reduces basic Rails configuration/installation to:

    gem 'resque-scheduler'