### PR TITLE
add support for queueing ActiveJob jobs

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -276,6 +276,8 @@ module Resque
             # CustomJobClass). Otherwise, pass off to Resque.
             if klass.respond_to?(:scheduled)
               klass.scheduled(queue, klass_name, *params)
+            elsif klass.respond_to?(:perform_later)
+              klass.set(queue: queue).perform_later(*params)
             else
               Resque.enqueue_to(queue, klass, *params)
             end


### PR DESCRIPTION
This allows resque scheduler to set the queue correctly for ActiveJobs when resque schedule's YAML configuration does not set the queue.  Depends on this resque PR:  https://github.com/resque/resque/pull/1713