### PR TITLE
Default 'quiet' to false when backgrounding.

### DIFF
--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -35,7 +35,7 @@ module Resque
         Resque::Scheduler.quiet = if options.key?(:quiet)
                                     !!options[:quiet]
                                   else
-                                    true
+                                    false
                                   end
 
         unless Process.respond_to?('daemon')

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -44,4 +44,10 @@ context 'Env' do
     env.setup
     assert_equal(false, Resque::Scheduler.dynamic)
   end
+
+  test 'quiet is false if not provided' do
+    env = new_env
+    env.setup
+    assert_equal(false, Resque::Scheduler.quiet)
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/resque/resque-scheduler/issues/565.

At present, the `quiet` option defaults to `true` if you're using `BACKGROUND` to daemonize resque-scheduler. This is a problem because there aren't any easy ways to change that default. You can't set `QUIET=0` or `QUIET=false` or anything like that, since the strings `"0"` and `"false"` will be interpreted as `true` by Cli. (That's probably a separate issue.) There's no `--no-quiet` option to disable this behaviour. The only way to do it that I've found is to use `INITIALIZER_PATH` to load an init file where you do `Resque::Scheduler.configure { |c| c.quiet = true }`, which is an awkward workaround.

The main problem is that the default for `quiet` is documented to be `false`, but it's implicitly `true` when `BACKGROUND` is set, which is surprising. This PR changes the default to `false` to be consistent throughout.