### PR TITLE
Require rufus-scheduler < 3.7

### DIFF
--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -57,5 +57,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
   spec.add_runtime_dependency 'resque', '>= 1.27'
-  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2'
+  # rufus-scheduler v3.7 causes a failure in test/multi_process_test.rb
+  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2', '< 3.7'
 end


### PR DESCRIPTION
With v3.7, we see the following error from `multi_process_test`:

```
resque-scheduler/vendor/bundle/ruby/2.4.0/gems/rufus-scheduler-3.7.0/lib/rufus/scheduler.rb:598:in `pop': No live threads left. Deadlock? (fatal)
1 threads, 1 sleeps current:0x00000000017765e0 main thread:0x00000000017765e0
* #<Thread:0x00000000017a9e18 sleep_forever>
   rb_thread_t:0x00000000017765e0 native:0x00007f454bb51700 int:0
   resque-scheduler/vendor/bundle/ruby/2.4.0/gems/rufus-scheduler-3.7.0/lib/rufus/scheduler.rb:598:in `pop'
   resque-scheduler/vendor/bundle/ruby/2.4.0/gems/rufus-scheduler-3.7.0/lib/rufus/scheduler.rb:598:in `no_time_limit_join'
   resque-scheduler/vendor/bundle/ruby/2.4.0/gems/rufus-scheduler-3.7.0/lib/rufus/scheduler.rb:148:in `join'
   resque-scheduler/lib/resque/scheduler.rb:380:in `stop_rufus_scheduler'
   resque-scheduler/lib/resque/scheduler.rb:384:in `before_shutdown'
   resque-scheduler/test/multi_process_test.rb:70:in `block (4 levels) in <top (required)>'
   resque-scheduler/test/multi_process_test.rb:92:in `block in fork_with_marshalled_pipe_and_result'
   resque-scheduler/test/multi_process_test.rb:89:in `fork'
   resque-scheduler/test/multi_process_test.rb:89:in `fork_with_marshalled_pipe_and_result'
   resque-scheduler/test/multi_process_test.rb:64:in `block (3 levels) in <top (required)>'
   resque-scheduler/test/multi_process_test.rb:63:in `times'
   resque-scheduler/test/multi_process_test.rb:63:in `block (2 levels) in <top (required)>'

E
================================================================================
Error: test_concurrent_shutdowns_and_startups_do_not_corrupt_the_schedule(Multi_Process): RuntimeError: forked process failed with pid 7680 exit 1
resque-scheduler/test/multi_process_test.rb:111:in `block in get_results_from_children'
resque-scheduler/test/multi_process_test.rb:108:in `each'
resque-scheduler/test/multi_process_test.rb:108:in `get_results_from_children'
resque-scheduler/test/multi_process_test.rb:76:in `block (2 levels) in <top (required)>'
================================================================================
```

You can see the error in [this CI job](https://travis-ci.com/github/hosamaly/resque-scheduler/jobs/490903813).