### PR TITLE
Ruby 3.0 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
+  - 3.0
   - 2.6
   - 2.5
   - 2.4

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -46,7 +46,7 @@
       <td><%= h(show_job_arguments(job['args'])) if job && delayed_timestamp_size == 1 %></td>
       <td>
         <% if job %>
-          <a href="<%=u URI("/delayed/jobs/#{URI.escape(job['class'])}?args=" + URI.encode(job['args'].to_json)) %>">All schedules</a>
+          <a href="<%=u URI("/delayed/jobs/#{CGI.escape(job['class'])}?args=" + URI.encode_www_form(job['args'].to_json)) %>">All schedules</a>
         <% end %>
       </td>
     </tr>

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -101,7 +101,7 @@ context 'on GET to /delayed' do
     test "contains link to all schedules for class #{job['class']}" do
       Resque.enqueue_at(Time.now + job['t'], job['class'], *job['args'])
       get '/delayed'
-      assert !(last_response.body =~ %r{/delayed/jobs/#{URI.escape(job['class'].to_s)}}).nil?
+      assert !(last_response.body =~ %r{/delayed/jobs/#{CGI.escape(job['class'].to_s)}}).nil?
     end
   end
 end
@@ -112,7 +112,7 @@ context 'on GET to /delayed/jobs/:klass' do
     Resque.enqueue_at(@t, SomeIvarJob, 'foo', 'bar')
     get(
       URI('/delayed/jobs/SomeIvarJob?args=' <<
-          URI.encode(%w(foo bar).to_json)).to_s
+          URI.encode_www_form(%w(foo bar).to_json)).to_s
     )
   end
 


### PR DESCRIPTION
`URI.escape` method has been deprecated and removed in Ruby 3 (https://github.com/ruby/uri/commit/61c6a47ebf1f2726b60a2bbd70964d64e14b1f98).