### PR TITLE
rufus-scheduler picks timezone from rails configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -407,9 +407,6 @@ Resque.set_schedule(name, config)
 
 #### Time zones
 
-Note that if you use the cron syntax, this will be interpreted as in the server time zone
-rather than the `config.time_zone` specified in Rails.
-
 You can explicitly specify the time zone that rufus-scheduler will use:
 
 ```yaml


### PR DESCRIPTION
Since rufus-schedule 3.3.3 time zone is taken from rails config if set. https://github.com/jmettraux/rufus-scheduler/blob/64591be6a2c80149839861389a0ed8708e279198/CHANGELOG.md#rufus-scheduler-333---released-2017-01-29