### PR TITLE
Ruby 3 support

### DIFF
--- a/lib/resque/scheduler/server.rb
+++ b/lib/resque/scheduler/server.rb
@@ -87,7 +87,7 @@ module Resque
         def delayed_jobs_klass
           begin
             klass = Resque::Scheduler::Util.constantize(params[:klass])
-            @args = JSON.load(URI.decode(params[:args]))
+            @args = JSON.load(CGI.unescape(params[:args]))
             @timestamps = Resque.scheduled_at(klass, *@args)
           rescue
             @timestamps = []

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -46,7 +46,7 @@
       <td><%= h(show_job_arguments(job['args'])) if job && delayed_timestamp_size == 1 %></td>
       <td>
         <% if job %>
-          <a href="<%=u URI("/delayed/jobs/#{CGI.escape(job['class'])}?args=" + URI.encode_www_form(job['args'])) %>">All schedules</a>
+          <a href="<%=u URI("/delayed/jobs/#{CGI.escape(job['class'])}?args=" + CGI.escape(job['args'].to_json)) %>">All schedules</a>
         <% end %>
       </td>
     </tr>

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -101,7 +101,7 @@ context 'on GET to /delayed' do
     test "contains link to all schedules for class #{job['class']}" do
       Resque.enqueue_at(Time.now + job['t'], job['class'], *job['args'])
       get '/delayed'
-      assert !(last_response.body =~ %r{/delayed/jobs/#{URI.escape(job['class'].to_s)}}).nil?
+      assert !(last_response.body =~ %r{/delayed/jobs/#{CGI.escape(job['class'].to_s)}}).nil?
     end
   end
 end
@@ -112,7 +112,7 @@ context 'on GET to /delayed/jobs/:klass' do
     Resque.enqueue_at(@t, SomeIvarJob, 'foo', 'bar')
     get(
       URI('/delayed/jobs/SomeIvarJob?args=' <<
-          URI.encode(%w(foo bar).to_json)).to_s
+          CGI.escape(%w(foo bar).to_json)).to_s
     )
   end
 
@@ -135,7 +135,7 @@ context 'on GET to /delayed/jobs/:klass' do
       Resque.enqueue_at(@t, Foo::Bar, 'foo', 'bar')
       get(
         URI('/delayed/jobs/Foo::Bar?args=' <<
-            URI.encode(%w(foo bar).to_json)).to_s
+            CGI.escape(%w(foo bar).to_json)).to_s
       )
     end
 


### PR DESCRIPTION
* removed `URI.decode/URI.escape` in favour of `CGI.unescape/CGI.escape`
* using CGI.escape(args.to_json) instead of URI.encode_www_form(args)