### PR TITLE
Update CI badge in README.md [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ resque-scheduler
 
 [![Dependency Status](https://gemnasium.com/badges/github.com/resque/resque-scheduler.svg)](https://gemnasium.com/github.com/resque/resque-scheduler)
 [![Gem Version](https://badge.fury.io/rb/resque-scheduler.svg)](https://badge.fury.io/rb/resque-scheduler)
-[![Build Status](https://travis-ci.org/resque/resque-scheduler.svg?branch=master)](https://travis-ci.org/resque/resque-scheduler)
+[![Build Status](https://github.com/resque/resque-scheduler/actions/workflows/ci.yml/badge.svg)](https://github.com/resque/resque-scheduler/actions/workflows/ci.yml)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/sxvf2086v5j0absb/branch/master?svg=true)](https://ci.appveyor.com/project/resque/resque-scheduler/branch/master)
 [![Code Climate](https://codeclimate.com/github/resque/resque-scheduler/badges/gpa.svg)](https://codeclimate.com/github/resque/resque-scheduler)
 


### PR DESCRIPTION
Changed from Travis CI to GitHub Actions.