### PR TITLE
Remove Ruby 2.3 from testing matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         ruby-version:
-          - 2.3
           - 2.4
           - 2.5
           - 2.6


### PR DESCRIPTION
Mimic the setup in https://github.com/resque/resque/blob/master/.github/workflows/ci.yml