### PR TITLE
Separate Rubocop and specs into two GH Action workflows

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -1,0 +1,27 @@
+name: Rubocop
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  rubocop:
+    name: Rubocop
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        ruby: [
+            2.4
+        ]
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+          bundler-cache: true
+      - name: Ruby linter
+        run: bundle exec rubocop

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -1,3 +1,5 @@
+name: Ruby specs
+
 on:
   push:
     branches: [master]

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ resque-scheduler
 
 [![Dependency Status](https://gemnasium.com/badges/github.com/resque/resque-scheduler.svg)](https://gemnasium.com/github.com/resque/resque-scheduler)
 [![Gem Version](https://badge.fury.io/rb/resque-scheduler.svg)](https://badge.fury.io/rb/resque-scheduler)
-[![Build Status](https://travis-ci.org/resque/resque-scheduler.svg?branch=master)](https://travis-ci.org/resque/resque-scheduler)
+[![Ruby specs](https://github.com/resque/resque-scheduler/actions/workflows/ruby.yml/badge.svg)](https://github.com/resque/resque-scheduler/actions)
+[![Rubocop](https://github.com/resque/resque-scheduler/actions/workflows/rubocop.yml/badge.svg)](https://github.com/resque/resque-scheduler/actions)
 [![Windows Build Status](https://ci.appveyor.com/api/projects/status/sxvf2086v5j0absb/branch/master?svg=true)](https://ci.appveyor.com/project/resque/resque-scheduler/branch/master)
 [![Code Climate](https://codeclimate.com/github/resque/resque-scheduler/badges/gpa.svg)](https://codeclimate.com/github/resque/resque-scheduler)
 
@@ -641,7 +642,7 @@ that happens on Travis CI and Appveyor:
 bundle install
 
 # Make sure tests are green before you change stuff
-bundle exec rake
+bundle exec rubocop && bundle exec rake
 # Change stuff
 # Repeat
 ```

--- a/Rakefile
+++ b/Rakefile
@@ -1,13 +1,9 @@
 # vim:fileencoding=utf-8
 require 'bundler/gem_tasks'
 require 'rake/testtask'
-require 'rubocop/rake_task'
 require 'yard'
 
-task default: [:rubocop, :test] unless RUBY_PLATFORM =~ /java/
-task default: [:test] if RUBY_PLATFORM =~ /java/
-
-RuboCop::RakeTask.new
+task default: :test
 
 Rake::TestTask.new do |t|
   t.libs << 'test'


### PR DESCRIPTION
What?
-
Fix CI!
As requested in https://github.com/resque/resque-scheduler/issues/712#issuecomment-925380319 :)

How?
-
Separate Rubocop and Ruby specs into two different GitHub Action workflows. 

Why?
-
Some builds were failing because Rubocop was failing on some Rubies. We don't need to run Rubocop against all Rubies so we now run Rubocop with only one ruby implementation.

I referred to https://github.com/rails/webpacker/tree/d7adcd20ddb77097a99a27f94491e78884c6ec59/.github/workflows for inspiration.