### PR TITLE
Minor fix for CHANGELOG and README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ## Unreleased
 
-## [4.5.0]
+## [4.5.0] - 2021-09-25
 ### Added
 - Support Ruby 3
 - Add optional argument to `remove_schedule` to control reloading of the schedule
@@ -444,6 +444,7 @@
 - Initial release
 
 [Unreleased]: https://github.com/resque/resque-scheduler/compare/v4.4.0...HEAD
+[4.5.0]: https://github.com/resque/resque-scheduler/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/resque/resque-scheduler/compare/v4.3.1...v4.4.0
 [4.3.1]: https://github.com/resque/resque-scheduler/compare/v4.3.0...v4.3.1
 [4.3.0]: https://github.com/resque/resque-scheduler/compare/v4.2.1...v4.3.0

--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ If you would like to setup a job that is executed manually you can configure lik
 
 ```yaml
 ImportOrdersManual:
-  description: 'Import Amazon Orders Manual'
   custom_job_class: 'AmazonMws::ImportOrdersJob'
   never: "* * * * *"
   queue: high


### PR DESCRIPTION
* Add the compare link and the release date on `4.5.0` section
* Remove duplicate `description` attributes