### PR TITLE
Require 'mocha/test_unit' instead of 'mocha/setup'

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,7 +3,7 @@ require 'simplecov'
 
 require 'test/unit'
 require 'minitest'
-require 'mocha/setup'
+require 'mocha/test_unit'
 require 'rack/test'
 require 'resque'
 require 'timecop'


### PR DESCRIPTION
It suppresses the following deprecation warning:

```
Mocha deprecation warning at /home/runner/work/resque-scheduler/resque-scheduler/test/test_helper.rb:6:in `require': Require 'mocha/test_unit', 'mocha/minitest' or 'mocha/api' instead of 'mocha/setup'.
```