### PR TITLE
Remove support for Ruby < 2.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
-## Unreleased
+## [Unreleased]
+### Changed
+- Remove support for Ruby < 2.3
 
 ## [4.5.0] - 2021-09-25
 ### Added
@@ -443,7 +445,7 @@
 ### Added
 - Initial release
 
-[Unreleased]: https://github.com/resque/resque-scheduler/compare/v4.4.0...HEAD
+[Unreleased]: https://github.com/resque/resque-scheduler/compare/v4.5.0...HEAD
 [4.5.0]: https://github.com/resque/resque-scheduler/compare/v4.4.0...v4.5.0
 [4.4.0]: https://github.com/resque/resque-scheduler/compare/v4.3.1...v4.4.0
 [4.3.1]: https://github.com/resque/resque-scheduler/compare/v4.3.0...v4.3.1

--- a/README.md
+++ b/README.md
@@ -571,7 +571,7 @@ Now make sure you're passing that file to resque-web like so:
 
 ### Running in the background
 
-(Only supported with ruby >= 1.9). There are scenarios where it's helpful for
+There are scenarios where it's helpful for
 the resque worker to run itself in the background (usually in combination with
 PIDFILE).  Use the BACKGROUND option so that rake will return as soon as the
 worker is started.

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -38,10 +38,6 @@ module Resque
                                     true
                                   end
 
-        unless Process.respond_to?('daemon')
-          abort 'background option is set, which requires ruby >= 1.9'
-        end
-
         Process.daemon(true, !Resque::Scheduler.quiet)
         Resque.redis._client.reconnect
       end

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -29,6 +29,8 @@ Gem::Specification.new do |spec|
   spec.homepage = 'http://github.com/resque/resque-scheduler'
   spec.license = 'MIT'
 
+  spec.required_ruby_version = '>= 2.3.0'
+
   spec.files = `git ls-files -z`.split("\0").reject do |f|
     f.match(%r{^(test|spec|features|examples|bin|tasks)/}) ||
       f.match(/^(Vagrantfile|Gemfile\.lock)/) ||

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -23,14 +23,6 @@ context 'Env' do
     env.setup
   end
 
-  test 'aborts when background is given and Process does not support daemon' do
-    Process.stubs(:daemon)
-    Process.expects(:respond_to?).with('daemon').returns(false)
-    env = new_env(background: true)
-    env.expects(:abort)
-    env.setup
-  end
-
   test 'keep set config if no option given' do
     Resque::Scheduler.configure { |c| c.dynamic = true }
     env = new_env


### PR DESCRIPTION
I noticed that `Gem::Specification#required_ruby_version` was not set when I was trying to bump rubocop version.
I think we can make resque-scheduler require Ruby 2.3, just like [resque does](https://github.com/resque/resque/blob/master/resque.gemspec#L23).