### PR TITLE
Unblock rufus-scheduler upgrade by fixing shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Remove support for Ruby < 2.3
 - Configuration to use a set of truthy values to enable boolean settings instead of simply existence
 - Add `delay_or_enqueue_at` for delaying existing jobs or creating a new job
+- Unblock rufus-scheduler lock on lower than 3.7 by fixing scheduler shutdown
 
 ## [4.5.0] - 2021-09-25
 ### Added

--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -377,7 +377,6 @@ module Resque
 
       def stop_rufus_scheduler
         rufus_scheduler.shutdown(:wait)
-        rufus_scheduler.join
       end
 
       def before_shutdown

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -61,5 +61,5 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'resque', '>= 1.27'
   # rufus-scheduler v3.7 causes a failure in test/multi_process_test.rb
   # rufus-scheduler v3.3 is missing a to_local method which fails tests
-  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2', '< 3.7', '!= 3.3'
+  spec.add_runtime_dependency 'rufus-scheduler', '~> 3.2', '!= 3.3'
 end


### PR DESCRIPTION
Updates #723

Looking into this more, it appears the use of calling `#join` on the scheduler is not needed when calling `#shutdown(:wait)` since that will block the current thread until shutdown.  The reason this worked before looks like simply `rufus-scheduler` unexpectedly supported this and it appears completely accidental.  Looking into the differences it looks the reason why is that the old `rufus-scheduler` method allowed calls on `#join` after shutdown because the `@thread` variable is never reset after shutdown (see https://github.com/jmettraux/rufus-scheduler/blob/v3.2.0/lib/rufus/scheduler.rb#L171).  After changes in v3.6.0, this is no longer allowed since it is using a queue system instead.