### PR TITLE
Version bump to 4.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
-## [Unreleased]
+## [4.6.0] - 2022-08-04
 ### Changed
 - Remove support for Ruby < 2.3
 - Configuration to use a set of truthy values to enable boolean settings instead of simply existence

--- a/lib/resque/scheduler/version.rb
+++ b/lib/resque/scheduler/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module Scheduler
-    VERSION = '4.5.0'.freeze
+    VERSION = '4.6.0'.freeze
   end
 end


### PR DESCRIPTION
This bumps version and sets the changelog header to reflect a 4.6.0 release
