### PR TITLE
Use non-deprecated form of Redis.sadd/srem

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -29,6 +29,7 @@ Resque Scheduler authors
 - Henrik Nyh
 - Hormoz Kheradmand
 - Ian Davies
+- Irving Reid
 - James Le Cuirot
 - Jarkko Mönkkönen
 - Jimmy Chao

--- a/bin/migrate_to_timestamps_set.rb
+++ b/bin/migrate_to_timestamps_set.rb
@@ -12,5 +12,5 @@ Resque.redis = ARGV[0]
 redis = Resque.redis
 Array(redis.keys('delayed:*')).each do |key|
   jobs = redis.lrange(key, 0, -1)
-  jobs.each { |job| redis.sadd("timestamps:#{job}", key) }
+  jobs.each { |job| redis.sadd("timestamps:#{job}", [key]) }
 end

--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -90,7 +90,7 @@ module Resque
         redis.rpush("delayed:#{timestamp.to_i}", encode(item))
 
         # Store the timestamps at with this item occurs
-        redis.sadd("timestamps:#{encode(item)}", "delayed:#{timestamp.to_i}")
+        redis.sadd("timestamps:#{encode(item)}", ["delayed:#{timestamp.to_i}"])
 
         # Now, add this timestamp to the zsets.  The score and the value are
         # the same since we'll be querying by timestamp, and we don't have
@@ -140,7 +140,7 @@ module Resque
         key = "delayed:#{timestamp.to_i}"
 
         encoded_item = redis.lpop(key)
-        redis.srem("timestamps:#{encoded_item}", key)
+        redis.srem("timestamps:#{encoded_item}", [key])
         item = decode(encoded_item)
 
         # If the list is empty, remove it.
@@ -257,7 +257,7 @@ module Resque
         key = "delayed:#{timestamp.to_i}"
         encoded_job = encode(job_to_hash(klass, args))
 
-        redis.srem("timestamps:#{encoded_job}", key)
+        redis.srem("timestamps:#{encoded_job}", [key])
         count = redis.lrem(key, 0, encoded_job)
         clean_up_timestamp(key, timestamp)
 
@@ -317,7 +317,7 @@ module Resque
         replies = redis.pipelined do |pipeline|
           timestamps.each do |key|
             pipeline.lrem(key, 0, encoded_job)
-            pipeline.srem("timestamps:#{encoded_job}", key)
+            pipeline.srem("timestamps:#{encoded_job}", [key])
           end
         end
 

--- a/lib/resque/scheduler/scheduling_extensions.rb
+++ b/lib/resque/scheduler/scheduling_extensions.rb
@@ -91,7 +91,7 @@ module Resque
           non_persistent_schedules[name] = decode(encode(config))
         end
 
-        redis.sadd(:schedules_changed, name)
+        redis.sadd(:schedules_changed, [name])
         reload_schedule! if reload
       end
 
@@ -105,7 +105,7 @@ module Resque
       def remove_schedule(name, reload = true)
         non_persistent_schedules.delete(name)
         redis.hdel(:persistent_schedules, name)
-        redis.sadd(:schedules_changed, name)
+        redis.sadd(:schedules_changed, [name])
 
         reload_schedule! if reload
       end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,6 +11,11 @@ $LOAD_PATH.unshift File.dirname(File.expand_path(__FILE__)) + '/../lib'
 require 'resque-scheduler'
 require 'resque/scheduler/server'
 
+# Raise on Redis deprecations if we're using a modern enough version of the Resque gem
+if Redis.respond_to?(:'raise_deprecations=')
+  Redis.raise_deprecations = Gem.loaded_specs['resque'].version >= Gem::Version.create('2.4')
+end
+
 ##
 # test/spec/mini 3
 # original work: http://gist.github.com/25455


### PR DESCRIPTION
This fixes the deprecation warnings for `Redis#sadd` and `Redis#srem` output by version 4.8 of `redis-rb`, following the example of the changes made to Resque in https://github.com/resque/resque/pull/1827

Other tests failed when upgrading `redis-rb` to 5.0.4, which is why I added the restriction to `resque-scheduler.gemspec`

To avoid future regressions, I enabled `Redis.raise_deprecations = true` so that the test suite is more likely to catch future Redis deprecations.