### PR TITLE
Fix `gethostbyaddr` deprecation warnings

### DIFF
--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -47,7 +47,7 @@ module Resque
 
         def hostname
           local_hostname = Socket.gethostname
-          Socket.gethostbyname(local_hostname).first
+          Addrinfo.getaddrinfo(local_hostname, 'http').first.getnameinfo.first
         rescue
           local_hostname
         end


### PR DESCRIPTION
Use supported Addrinfo APIs to get the fully qualified local host name.