### PR TITLE
Prompt for confirmation on 'Clear Delayed Jobs'

### DIFF
--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -16,6 +16,14 @@
   Showing <%= start = params[:start].to_i %> to <%= start + 20 %> of <b><%= size %></b> timestamps
 </p>
 
+<% if size > 0 %>
+  <div style="padding-bottom: 10px">
+    <form method="POST" action="<%= u 'delayed/clear' %>" class='clear-delayed confirmSubmission'>
+      <input type='submit' name='' value='Clear Delayed Jobs' />
+    </form>
+  </div>
+<% end %>
+
 <table>
   <tr>
     <th></th>
@@ -52,12 +60,5 @@
     </tr>
   <% end %>
 </table>
-
-<% if size > 0 %>
-  <br>
-  <form method="POST" action="<%= u 'delayed/clear' %>" class='clear-delayed'>
-    <input type='submit' name='' value='Clear Delayed Jobs' />
-  </form>
-<% end %>
 
 <%= partial :next_more, :start => start, :size => size %>

--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -35,7 +35,7 @@
   </tr>
   <% resque.delayed_queue_peek(start, 20).each do |timestamp| %>
     <tr>
-      <td>
+      <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
         <form action="<%= u "/delayed/queue_now" %>" method="post">
           <input type="hidden" name="timestamp" value="<%= timestamp.to_i %>">
           <input type="submit" value="Queue now">

--- a/lib/resque/scheduler/server/views/search.erb
+++ b/lib/resque/scheduler/server/views/search.erb
@@ -13,13 +13,13 @@
   </tr>
   <% delayed.each do |job| %>
       <tr>
-        <td>
+        <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
           <form action="<%= u "/delayed/queue_now" %>" method="post">
             <input type="hidden" name="timestamp" value="<%= job['timestamp'].to_i %>">
             <input type="submit" value="Queue now">
           </form>
         </td>
-        <td>
+        <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
           <form action="<%= u "/delayed/cancel_now" %>" method="post">
             <input type="hidden" name="timestamp" value="<%= job['timestamp'].to_i %>">
             <input type="hidden" name="klass" value="<%= job['class'] %>">


### PR DESCRIPTION
Fix #659

This PR displays a prompt for confirmation when 'Clear Delayed Jobs' button is clicked.
Also does the following:
- Move the button to above the table in order to keep it away from the paging links.
- Adjust style so that buttons do not stick out.

## Delayed

### Before this change

![before_delay](https://user-images.githubusercontent.com/32959831/191903523-b40f6757-cabd-49eb-ba62-c5a19e017573.png)

## After this change

![delay1_1](https://user-images.githubusercontent.com/32959831/191903683-99be2196-00fa-48f4-8bb2-ca7c1d672133.png)
![delay2_2](https://user-images.githubusercontent.com/32959831/191903685-deaa40d5-6697-4991-bfdc-21891582e4fd.png)

## Search

### Before this change

![before_search](https://user-images.githubusercontent.com/32959831/191903531-63622ada-cb3e-4e05-9a7b-070776e08066.png)

## After this change

![after_search](https://user-images.githubusercontent.com/32959831/191903646-7acea9f3-b036-47a0-afbc-602a4355586e.png)
