### PR TITLE
Use `Resque::DataStore#reconnect` for redis-rb v5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ following task to wherever tasks are kept, such as
 ```ruby
 task 'resque:pool:setup' do
   Resque::Pool.after_prefork do |job|
-    Resque.redis._client.reconnect
+    Resque.redis.reconnect
   end
 end
 ```

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -39,7 +39,7 @@ module Resque
                                   end
 
         Process.daemon(true, !Resque::Scheduler.quiet)
-        Resque.redis._client.reconnect
+        Resque.redis.reconnect
       end
 
       def setup_pid_file

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -15,10 +15,8 @@ context 'Env' do
 
   test 'reconnects redis when background is true' do
     Process.stubs(:daemon)
-    mock_redis_client = mock('redis_client')
     mock_redis = mock('redis')
-    mock_redis.expects(:_client).returns(mock_redis_client)
-    mock_redis_client.expects(:reconnect)
+    mock_redis.expects(:reconnect)
     Resque.expects(:redis).returns(mock_redis)
     env = new_env(background: true)
     env.setup


### PR DESCRIPTION
This PR will fix a part of #750.

`Redis::Client#reconnect` has been removed from redis-rb v5.0.0.
This PR replaces it with `Resque::DataStore#reconnect`.
It is available since Resque v1.27.0, so it is backward compatible.

- Resque v1.27.0
  https://github.com/resque/resque/blob/v1.27.0/lib/resque/data_store.rb#L80-L83
  ```ruby
      # Force a reconnect to Redis.
      def reconnect
        @redis.client.reconnect
      end
  ```
- Resque v2.4.0
  https://github.com/resque/resque/blob/v2.4.0/lib/resque/data_store.rb#L79-L85
  ```ruby
      # Force a reconnect to Redis without closing the connection in the parent
      # process after a fork.
      def reconnect
        @redis.disconnect!
        @redis.ping
        nil
      end
   ```