### PR TITLE
Fix tests for compatibility with redis-rb v5.0

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,30 +28,42 @@ jobs:
           - 3.1
         resque-version:
           - "master"
-          - "~> 2.2.0"
+          - "~> 2.4.0"
           - "~> 1.27"
         rufus-scheduler:
           - "3.2"
           - "3.4"
           - "3.5"
           - "3.6"
+        redis-version:
+          - "~> 4.x"
+          - "~> 5.x"
         exclude:
           - ruby-version: head
             rufus-scheduler: 3.2
 
           - ruby-version: 2.3
-            resque-version: 1.27
+            resque-version: "~> 1.27"
             rufus-scheduler: 3.4
           - ruby-version: 2.3
-            resque-version: 1.27
+            resque-version: "~> 1.27"
             rufus-scheduler: 3.5
           - ruby-version: 2.5
-            resque-version: 2.2.0
+            resque-version: "~> 2.4.0"
             rufus-scheduler: 3.5
           - ruby-version: 2.5
             resque-version: master
             rufus-scheduler: 3.2
+
+          - ruby-version: 2.3
+            redis-version: "~> 5.x"
+          - ruby-version: 2.4
+            redis-version: "~> 5.x"
+
+          - resque-version: "~> 1.27"
+            redis-version: "~> 5.x"
     env:
+      REDIS_VERSION: "${{ matrix.redis-version }}"
       RESQUE: "${{ matrix.resque-version }}"
       RUFUS_SCHEDULER: "${{ matrix.rufus-scheduler }}"
       COVERAGE: 1

--- a/Gemfile
+++ b/Gemfile
@@ -15,4 +15,11 @@ else
   gem 'rufus-scheduler', rufus_scheduler_version
 end
 
+case redis_version = ENV.fetch('REDIS_VERSION', '~> 5.x')
+when 'master'
+  gem 'redis', git: 'https://github.com/redis/redis-rb'
+else
+  gem 'redis', redis_version
+end
+
 gemspec

--- a/Gemfile
+++ b/Gemfile
@@ -15,9 +15,11 @@ else
   gem 'rufus-scheduler', rufus_scheduler_version
 end
 
-case redis_version = ENV.fetch('REDIS_VERSION', '~> 5.x')
+case redis_version = ENV.fetch('REDIS_VERSION', 'latest')
 when 'master'
   gem 'redis', git: 'https://github.com/redis/redis-rb'
+when 'latest'
+  gem 'redis'
 else
   gem 'redis', redis_version
 end

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -39,7 +39,7 @@ module Resque
                                   end
 
         Process.daemon(true, !Resque::Scheduler.quiet)
-        Resque.redis._client.reconnect
+        Resque.redis.reconnect
       end
 
       def setup_pid_file

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -574,10 +574,10 @@ context 'DelayedQueue' do
   test 'remove_delayed_selection ignores last_enqueued_at redis key' do
     t = Time.now + 120
     Resque.enqueue_at(t, SomeIvarJob)
-    Resque.last_enqueued_at(SomeIvarJob, t)
+    Resque.last_enqueued_at(SomeIvarJob.to_s, t.to_s)
 
     assert_equal(0, Resque.remove_delayed_selection { |a| a.first == 'bar' })
-    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob))
+    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob.to_s))
   end
 
   test 'remove_delayed_selection removes item by class' do
@@ -716,10 +716,10 @@ context 'DelayedQueue' do
   test 'enqueue_delayed_selection ignores last_enqueued_at redis key' do
     t = Time.now + 120
     Resque.enqueue_at(t, SomeIvarJob)
-    Resque.last_enqueued_at(SomeIvarJob, t)
+    Resque.last_enqueued_at(SomeIvarJob.to_s, t.to_s)
 
     assert_equal(0, Resque.enqueue_delayed_selection { |a| a.first == 'bar' })
-    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob))
+    assert_equal(t.to_s, Resque.get_last_enqueued_at(SomeIvarJob.to_s))
   end
 
   test 'enqueue_delayed_selection enqueues item by class' do

--- a/test/env_test.rb
+++ b/test/env_test.rb
@@ -15,10 +15,8 @@ context 'Env' do
 
   test 'reconnects redis when background is true' do
     Process.stubs(:daemon)
-    mock_redis_client = mock('redis_client')
     mock_redis = mock('redis')
-    mock_redis.expects(:_client).returns(mock_redis_client)
-    mock_redis_client.expects(:reconnect)
+    mock_redis.expects(:reconnect)
     Resque.expects(:redis).returns(mock_redis)
     env = new_env(background: true)
     env.setup

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -344,7 +344,7 @@ context 'DELETE /schedule when dynamic' do
   end
 
   test 'redirects to schedule page' do
-    delete '/schedule'
+    delete '/schedule', job_name: 'job_with_params'
 
     status = last_response.status
     redirect_location = last_response.original_headers['Location']

--- a/test/scheduler_args_test.rb
+++ b/test/scheduler_args_test.rb
@@ -10,6 +10,7 @@ context 'scheduling jobs with arguments' do
       c.quiet = true
       c.poll_sleep_amount = nil
     end
+    Resque.data_store.redis.flushall
   end
 
   test 'enqueue_from_config puts stuff in resque without class loaded' do

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -184,7 +184,7 @@ context 'Resque::Scheduler' do
     last_enqueued_at = sleep_until(10) do
       Resque.get_last_enqueued_at(name)
     end
-    Resque.last_enqueued_at(name, nil)
+    Resque.last_enqueued_at(name, '')
     assert !last_enqueued_at.nil?
   end
 
@@ -203,7 +203,7 @@ context 'Resque::Scheduler' do
     end
 
     Resque::Scheduler.unstub(:enqueue)
-    Resque.last_enqueued_at(name, nil)
+    Resque.last_enqueued_at(name, '')
     assert last_enqueued_at.nil?
   end
 


### PR DESCRIPTION
This PR fixes failing tests with redis-rb v5.0,
and also added matrix for redis-rb v4 and v5.

Here are the details:

- Field and value for hash must be String, Integer or Float
  - redis-rb 4.x used to call `to_s` on arguments, but redis-rb 5.x won't.
  - See here: https://github.com/redis/redis-rb/issues/1143#issuecomment-1231365756
- Use `Resque::DataStore#reconnect` instead of removed `Redis::Client#reconnect`
  - #756 already has this change, 
    but I would like to make all CI pass, so I included the same one.
- Added matrix redis version
  - Test with redis-rb v4.x and v5.x
  - Update resque test matrix from `~> 2.2.0` to `~> 2.4.0`
  - Exclude the combination of the following:
    - redis-rb v5.x with Ruby 2.4 or older
    - redis-rb v5.x with Resque 1.27.x
  - Fix resque-version in exclusions
    - They should be started with `~> `.