### PR TITLE
Update code sample on reconnect

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ following task to wherever tasks are kept, such as
 ```ruby
 task 'resque:pool:setup' do
   Resque::Pool.after_prefork do |job|
-    Resque.redis._client.reconnect
+    Resque.redis.reconnect
   end
 end
 ```


### PR DESCRIPTION
refs: #756
This PR updates the sample code in README.md to use `Resque::DataStore#reconnect` instead of `Redis::Client#reconnect`.