### PR TITLE
Replace `Socket.gethostbyname` with `Addrinfo.getaddrinfo`

### DIFF
--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -47,7 +47,7 @@ module Resque
 
         def hostname
           local_hostname = Socket.gethostname
-          Addrinfo.getaddrinfo(local_hostname).first
+          Addrinfo.getaddrinfo(local_hostname, nil).first
         rescue
           local_hostname
         end

--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -47,7 +47,7 @@ module Resque
 
         def hostname
           local_hostname = Socket.gethostname
-          Socket.gethostbyname(local_hostname).first
+          Addrinfo.getaddrinfo(local_hostname).first
         rescue
           local_hostname
         end


### PR DESCRIPTION
Since `Socket.gethostbyname` is already deprecated, replaced it with `Addrinfo.getaddrinfo`

Ref: https://bugs.ruby-lang.org/issues/13097