### PR TITLE
Add logfmt option for logging output

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -89,3 +89,4 @@ Resque Scheduler authors
 - sawanoboly
 - serek
 - iloveitaly
+- treacher

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ requiring `resque` and `resque/scheduler` (default empty).
 * `RESQUE_SCHEDULER_INTERVAL` - Interval in seconds for checking if a
 scheduled job must run (coerced with `Kernel#Float()`) (default `5`)
 * `LOGFILE` - Log file name (default empty, meaning `$stdout`)
-* `LOGFORMAT` - Log output format to use (either `'text'` or `'json'`,
+* `LOGFORMAT` - Log output format to use (either `'text'`, `'json'` or `'logfmt'`,
 default `'text'`)
 * `PIDFILE` - If non-empty, write process PID to file (default empty)
 * `QUIET` - Silence most output if non-empty (equivalent to a level of
@@ -663,7 +663,7 @@ are toggled by environment variables:
   - `QUIET` will stop logging anything. Completely silent.
   - `VERBOSE` opposite of 'QUIET'; will log even debug information
   - `LOGFILE` specifies the file to write logs to. (default standard output)
-  - `LOGFORMAT` specifies either "text" or "json" output format
+  - `LOGFORMAT` specifies either "text", "json" or "logfmt" output format
     (default "text")
 
 All of these variables are optional and will be given the following default

--- a/lib/resque/scheduler/configuration.rb
+++ b/lib/resque/scheduler/configuration.rb
@@ -44,7 +44,7 @@ module Resque
         @logfile ||= environment['LOGFILE']
       end
 
-      # Sets whether to log in 'text' or 'json'
+      # Sets whether to log in 'text', 'json' or 'logfmt'
       attr_writer :logformat
 
       def logformat

--- a/lib/resque/scheduler/logger_builder.rb
+++ b/lib/resque/scheduler/logger_builder.rb
@@ -15,7 +15,7 @@ module Resque
       #   - :quiet if logger needs to be silent for all levels. Default - false
       #   - :verbose if there is a need in debug messages. Default - false
       #   - :log_dev to output logs into a desired file. Default - STDOUT
-      #   - :format log format, either 'text' or 'json'. Default - 'text'
+      #   - :format log format, either 'text', 'json' or 'logfmt'. Default - 'text'
       #
       # Example:
       #
@@ -65,6 +65,15 @@ module Resque
             timestamp: datetime.iso8601,
             msg: msg
           ) + "\n"
+        end
+      end
+
+      def logfmt_formatter
+        proc do |severity, datetime, _progname, msg|
+          "Timestamp=\"#{datetime.iso8601}\" " \
+          "SeverityText=\"#{severity}\" " \
+          'InstrumentationScope="resque-scheduler" ' \
+          "Body=\"#{msg}\"\n"
         end
       end
     end

--- a/lib/resque/scheduler/logger_builder.rb
+++ b/lib/resque/scheduler/logger_builder.rb
@@ -71,10 +71,10 @@ module Resque
 
       def logfmt_formatter
         proc do |severity, datetime, progname, msg|
-          "Timestamp=\"#{datetime.iso8601}\" " \
-          "SeverityText=\"#{severity}\" " \
-          "InstrumentationScope=\"#{progname}\" " \
-          "Body=\"#{msg}\"\n"
+          "timestamp=\"#{datetime.iso8601}\" " \
+          "level=\"#{severity}\" " \
+          "progname=\"#{progname}\" " \
+          "msg=\"#{msg}\"\n"
         end
       end
     end

--- a/lib/resque/scheduler/logger_builder.rb
+++ b/lib/resque/scheduler/logger_builder.rb
@@ -32,6 +32,7 @@ module Resque
       # Returns an instance of MonoLogger
       def build
         logger = MonoLogger.new(@log_dev)
+        logger.progname = 'resque-scheduler'.freeze
         logger.level = level
         logger.formatter = send(:"#{@format}_formatter")
         logger
@@ -50,8 +51,8 @@ module Resque
       end
 
       def text_formatter
-        proc do |severity, datetime, _progname, msg|
-          "resque-scheduler: [#{severity}] #{datetime.iso8601}: #{msg}\n"
+        proc do |severity, datetime, progname, msg|
+          "#{progname}: [#{severity}] #{datetime.iso8601}: #{msg}\n"
         end
       end
 
@@ -59,7 +60,7 @@ module Resque
         proc do |severity, datetime, progname, msg|
           require 'json'
           JSON.dump(
-            name: 'resque-scheduler',
+            name: progname,
             progname: progname,
             level: severity,
             timestamp: datetime.iso8601,
@@ -69,10 +70,10 @@ module Resque
       end
 
       def logfmt_formatter
-        proc do |severity, datetime, _progname, msg|
+        proc do |severity, datetime, progname, msg|
           "Timestamp=\"#{datetime.iso8601}\" " \
           "SeverityText=\"#{severity}\" " \
-          'InstrumentationScope="resque-scheduler" ' \
+          "InstrumentationScope=\"#{progname}\" " \
           "Body=\"#{msg}\"\n"
         end
       end

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -150,6 +150,7 @@ context 'Resque::Scheduler' do
         Resque::Scheduler.log! 'another thing'
 
         expected_output = "resque-scheduler: [INFO] #{DateTime.now.iso8601}: another thing\n"
+
         assert_equal($stdout.string, expected_output)
       end
     end
@@ -170,8 +171,8 @@ context 'Resque::Scheduler' do
       Timecop.freeze do
         Resque::Scheduler.log! 'another thing'
 
-        expected_output = "Timestamp=\"#{DateTime.now.iso8601}\" SeverityText=\"INFO\" " \
-                          "InstrumentationScope=\"resque-scheduler\" Body=\"another thing\"\n"
+        expected_output = "timestamp=\"#{DateTime.now.iso8601}\" level=\"INFO\" " \
+                          "progname=\"resque-scheduler\" msg=\"another thing\"\n"
 
         assert_equal($stdout.string, expected_output)
       end

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -118,8 +118,19 @@ context 'Resque::Scheduler' do
     end
 
     test 'logs with json' do
-      Resque::Scheduler.log! 'whatever'
-      assert $stdout.string =~ /"msg":"whatever"/
+      Timecop.freeze do
+        Resque::Scheduler.log! 'another thing'
+
+        expected_output = {
+          name: 'resque-scheduler',
+          progname: 'resque-scheduler',
+          level: 'INFO',
+          timestamp: DateTime.now.iso8601,
+          msg: 'another thing'
+        }.to_json + "\n"
+
+        assert_equal($stdout.string, expected_output)
+      end
     end
   end
 
@@ -135,8 +146,12 @@ context 'Resque::Scheduler' do
     end
 
     test 'logs with text' do
-      Resque::Scheduler.log! 'another thing'
-      assert $stdout.string =~ /: another thing/
+      Timecop.freeze do
+        Resque::Scheduler.log! 'another thing'
+
+        expected_output = "resque-scheduler: [INFO] #{DateTime.now.iso8601}: another thing\n"
+        assert_equal($stdout.string, expected_output)
+      end
     end
   end
 
@@ -158,7 +173,7 @@ context 'Resque::Scheduler' do
         expected_output = "Timestamp=\"#{DateTime.now.iso8601}\" SeverityText=\"INFO\" " \
                           "InstrumentationScope=\"resque-scheduler\" Body=\"another thing\"\n"
 
-        assert_equal $stdout.string, expected_output
+        assert_equal($stdout.string, expected_output)
       end
     end
   end

--- a/test/scheduler_setup_test.rb
+++ b/test/scheduler_setup_test.rb
@@ -139,4 +139,27 @@ context 'Resque::Scheduler' do
       assert $stdout.string =~ /: another thing/
     end
   end
+
+  context 'logger with logfmt formatter' do
+    setup do
+      nullify_logger
+      Resque::Scheduler.logformat = 'logfmt'
+      $stdout = StringIO.new
+    end
+
+    teardown do
+      $stdout = STDOUT
+    end
+
+    test 'logs with logfmt' do
+      Timecop.freeze do
+        Resque::Scheduler.log! 'another thing'
+
+        expected_output = "Timestamp=\"#{DateTime.now.iso8601}\" SeverityText=\"INFO\" " \
+                          "InstrumentationScope=\"resque-scheduler\" Body=\"another thing\"\n"
+
+        assert_equal $stdout.string, expected_output
+      end
+    end
+  end
 end


### PR DESCRIPTION
### Context

This PR is for adding support for the [logfmt](https://brandur.org/logfmt) logging format.

I've also made a couple of small changes, currently the JSON logging formatter always outputs nil for `progname` this is because the value needs to be explicitly set after the logger is instantiated. I've set this to `resque-scheduler` and used the `progname` variable.

I've updated the tests so that they're testing the entire log line and have left the `name` field for JSON logging for backwards compatibility.

### Testing
- [x] Unit tests
- [x] Tested locally with resque-scheduler and observed locally that the logs were printed as expected.