### PR TITLE
Replace gethostbyname with Addrinfo.getaddrinfo

### DIFF
--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -47,7 +47,7 @@ module Resque
 
         def hostname
           local_hostname = Socket.gethostname
-          Socket.gethostbyname(local_hostname).first
+          Addrinfo.getaddrinfo(local_hostname, nil).first.getnameinfo.first
         rescue
           local_hostname
         end


### PR DESCRIPTION
This addresses the depreciation warning:

```
/gems/resque-scheduler-4.5.0/lib/resque/scheduler/lock/base.rb:50: warning: Socket.gethostbyname is deprecated; use Addrinfo.getaddrinfo instead.
```