### PR TITLE
Update CI matrix and fix tests

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -26,6 +26,7 @@ jobs:
           - 2.7
           - "3.0"
           - 3.1
+          - 3.2
         resque-version:
           - "master"
           - "~> 2.4.0"

--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -42,6 +42,8 @@ jobs:
         exclude:
           - ruby-version: head
             rufus-scheduler: 3.2
+          - ruby-version: 3.2
+            rufus-scheduler: 3.2
 
           - ruby-version: 2.3
             resque-version: "~> 1.27"

--- a/Gemfile
+++ b/Gemfile
@@ -24,4 +24,6 @@ else
   gem 'redis', redis_version
 end
 
+gem 'sinatra', '> 2.0'
+
 gemspec

--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -1,7 +1,7 @@
 # vim:fileencoding=utf-8
 require_relative 'test_helper'
 
-require 'resque/server/test_helper'
+require_relative 'server/test_helper'
 
 context 'on GET to /schedule' do
   setup { get '/schedule' }

--- a/test/server/test_helper.rb
+++ b/test/server/test_helper.rb
@@ -1,0 +1,19 @@
+require 'rack/test'
+require 'resque/server'
+
+module Resque
+  module TestHelper
+    class Test::Unit::TestCase
+      include Rack::Test::Methods
+      def app
+        Resque::Server.new
+      end
+
+      def self.should_respond_with_success
+        test "should respond with success" do
+          assert last_response.ok?, last_response.errors
+        end
+      end
+    end
+  end
+end

--- a/test/server/test_helper.rb
+++ b/test/server/test_helper.rb
@@ -3,14 +3,14 @@ require 'resque/server'
 
 module Resque
   module TestHelper
-    class Test::Unit::TestCase
+    class Test::Unit::TestCase # rubocop:disable Style/ClassAndModuleChildren
       include Rack::Test::Methods
       def app
         Resque::Server.new
       end
 
       def self.should_respond_with_success
-        test "should respond with success" do
+        test 'should respond with success' do
           assert last_response.ok?, last_response.errors
         end
       end


### PR DESCRIPTION
This PR tweaks test codes.
- Add Ruby 3.2 to the CI matrix
  - I wanted to add ruby-head as well, but decided against it since mono_logger issue mentioned at https://github.com/resque/resque/issues/1856 has not yet been resolved.
- Ensure that Sinatra > 2.0 is used
  - For some reason, Sinatra 1.0 may be installed.
    If 1.0 is used, the following error occurs.
    ```
    <internal:/opt/hostedtoolcache/Ruby/3.2.1/x64/lib/ruby/3.2.0/rubygems/core_ext/kernel_require.rb>:37:in `require': cannot load such file -- rack/showexceptions (LoadError)
    Did you mean?  rack/show_exceptions
    ```
- Copy `resque/server/test_helper` from Resque and use it
  - I removed this file at https://github.com/resque/resque/pull/1851 because it was not used in Resque side, but I found that it was used in this project.
  I believe the Resque changes should be left as is, as it is only needed for testing.