### PR TITLE
Fixed Queue now button misalignment

### DIFF
--- a/lib/resque/scheduler/server/views/delayed.erb
+++ b/lib/resque/scheduler/server/views/delayed.erb
@@ -27,8 +27,8 @@
   </tr>
   <% resque.delayed_queue_peek(start, 20).each do |timestamp| %>
     <tr>
-      <td>
-        <form action="<%= u "/delayed/queue_now" %>" method="post">
+      <td style="padding-top: 12px; padding-bottom: 2px; width: 10px">
+        <form action="<%= u "/delayed/queue_now" %>" method="post" style="margin-left: 0">
           <input type="hidden" name="timestamp" value="<%= timestamp.to_i %>">
           <input type="submit" value="Queue now">
         </form>


### PR DESCRIPTION
Fixed Queue now button misalignment.

I referred to:
https://github.com/resque/resque-scheduler/blob/121e3427d1211baf8354067321d1f1dd14c7e4a1/lib/resque/scheduler/server/views/scheduler.erb#L42-L43

## before
![image](https://user-images.githubusercontent.com/12048864/231811283-a9f02ca7-6c67-4f99-82ee-45a6e041de89.png)

## after
![image](https://user-images.githubusercontent.com/12048864/231811024-5b6dc1ce-1c98-4cf6-9cb7-0a6c4c5fb0bb.png)