### PR TITLE
test fixes

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -250,15 +250,15 @@ module Resque
         # be safe as our ltrim is inside the multi block and therefore also would have been
         # aborted. So nothing would have been queued, but also nothing lost from the bucket.
         watch_result = Resque.redis.watch(timestamp_bucket_key) do
-          Resque.redis.multi do
+          Resque.redis.multi do |pipeline|
             encoded_jobs_to_requeue.each do |encoded_job|
-              Resque.redis.srem("timestamps:#{encoded_job}", timestamp_bucket_key)
+              pipeline.srem("timestamps:#{encoded_job}", timestamp_bucket_key)
 
               decoded_job = Resque.decode(encoded_job)
               enqueue(decoded_job)
             end
 
-            Resque.redis.ltrim(timestamp_bucket_key, batch_size, -1)
+            pipeline.ltrim(timestamp_bucket_key, batch_size, -1)
           end
         end
 

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -321,7 +321,7 @@ context 'DelayedQueue' do
   test 'calls klass#scheduled when enqueuing jobs if it exists' do
     t = Time.now - 60
     FakeCustomJobClassEnqueueAt.expects(:scheduled)
-                               .once.with(:test, FakeCustomJobClassEnqueueAt.to_s, foo: 'bar')
+                               .once.with(:test, FakeCustomJobClassEnqueueAt.to_s, { foo: 'bar' })
     Resque.enqueue_at(t, FakeCustomJobClassEnqueueAt, foo: 'bar')
   end
 
@@ -332,7 +332,7 @@ context 'DelayedQueue' do
       Resque.inline = true
       t = Time.now - 60
       FakeCustomJobClassEnqueueAt.expects(:scheduled)
-                                 .once.with(:test, FakeCustomJobClassEnqueueAt.to_s, foo: 'bar')
+                                 .once.with(:test, FakeCustomJobClassEnqueueAt.to_s, { foo: 'bar' })
       Resque.enqueue_at(t, FakeCustomJobClassEnqueueAt, foo: 'bar')
     ensure
       Resque.inline = old_val

--- a/test/scheduler_args_test.rb
+++ b/test/scheduler_args_test.rb
@@ -195,7 +195,7 @@ context 'scheduling jobs with arguments' do
       args:
         key: value
     YAML
-    SomeIvarJob.expects(:perform).once.with('key' => 'value')
+    SomeIvarJob.expects(:perform).once.with({ 'key' => 'value' })
     Resque.reserve('ivar').perform
   end
 
@@ -208,7 +208,7 @@ context 'scheduling jobs with arguments' do
           second_key: value
     YAML
     SomeIvarJob.expects(:perform).once
-               .with('first_key' => { 'second_key' => 'value' })
+               .with({ 'first_key' => { 'second_key' => 'value' } })
     Resque.reserve('ivar').perform
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,7 +13,14 @@ require 'resque/scheduler/server'
 
 # Raise on Redis deprecations if we're using a modern enough version of the Resque gem
 if Redis.respond_to?(:'raise_deprecations=')
-  Redis.raise_deprecations = Gem.loaded_specs['resque'].version >= Gem::Version.create('2.4')
+  Redis.raise_deprecations = Gem.loaded_specs['resque'].version >= Gem::Version.create('2.4') &&
+    Gem.loaded_specs['redis'].version >= Gem::Version.create('5.0')
+end
+
+if RUBY_VERSION >= '2.7.0'
+  Mocha.configure do |c|
+    c.strict_keyword_argument_matching = true
+  end
 end
 
 ##


### PR DESCRIPTION
Gets the test suite back to green by fixing a few deprecation warnings and then not raising on deprecation warnings for older versions of the redis gem.
