### PR TITLE
Fix json dump crasher with JSON 2.7.0+

### DIFF
--- a/lib/resque/scheduler/logger_builder.rb
+++ b/lib/resque/scheduler/logger_builder.rb
@@ -59,13 +59,14 @@ module Resque
       def json_formatter
         proc do |severity, datetime, progname, msg|
           require 'json'
-          JSON.dump(
+          log_data = {
             name: progname,
             progname: progname,
             level: severity,
             timestamp: datetime.iso8601,
             msg: msg
-          ) + "\n"
+          }
+          JSON.dump(log_data) + "\n"
         end
       end
 


### PR DESCRIPTION
Attempting to fix a crasher that primarily affects Ruby 3+ when using JSON 2.7.0 when dumping logs to JSON.

Thanks @mishina2228 for pointing out this is related to https://github.com/flori/json/issues/553