### PR TITLE
Finish fixing CVE-2022-44303, XSS in delayed_schedules

### DIFF
--- a/lib/resque/scheduler/server/views/delayed_schedules.erb
+++ b/lib/resque/scheduler/server/views/delayed_schedules.erb
@@ -1,4 +1,4 @@
-<h1>Delayed jobs scheduled for <%=h params[:klass] %> (<%= show_job_arguments(@args) %>)</h1>
+<h1>Delayed jobs scheduled for <%=h params[:klass] %> (<%=h show_job_arguments(@args) %>)</h1>
 
 <table class='jobs'>
 <tr>


### PR DESCRIPTION
When writing up the security advisory for CVE-2022-44303, I realized there was still XSS in the args parameters. This finishes fixing that.
