### PR TITLE
Expose timeout for lock via environment variable configuration

### DIFF
--- a/lib/resque/scheduler/cli.rb
+++ b/lib/resque/scheduler/cli.rb
@@ -15,7 +15,8 @@ module Resque
       quiet: 'QUIET',
       pidfile: 'PIDFILE',
       poll_sleep_amount: 'RESQUE_SCHEDULER_INTERVAL',
-      verbose: 'VERBOSE'
+      verbose: 'VERBOSE',
+      lock_timeout: 'LOCK_TIMEOUT'
     }.freeze
 
     class Cli

--- a/lib/resque/scheduler/configuration.rb
+++ b/lib/resque/scheduler/configuration.rb
@@ -80,6 +80,13 @@ module Resque
           Float(environment.fetch('RESQUE_SCHEDULER_INTERVAL', '5'))
       end
 
+      # Sets timeout for Resque::Scheduler::Lock::Base
+      attr_writer :lock_timeout
+
+      def lock_timeout
+        @lock_timeout ||= environment.fetch('LOCK_TIMEOUT', 60 * 3).to_i
+      end
+
       private
 
       # Copied from https://github.com/rails/rails/blob/main/activemodel/lib/active_model/type/boolean.rb#L17

--- a/lib/resque/scheduler/env.rb
+++ b/lib/resque/scheduler/env.rb
@@ -54,6 +54,7 @@ module Resque
         at_exit { cleanup_pid_file }
       end
 
+      # rubocop:disable Metrics/AbcSize
       def setup_scheduler_configuration
         Resque::Scheduler.configure do |c|
           c.app_name = options[:app_name] if options.key?(:app_name)
@@ -66,6 +67,8 @@ module Resque
 
           c.logformat = options[:logformat] if options.key?(:logformat)
 
+          c.lock_timeout = options[:lock_timeout] if options.key?(:lock_timeout)
+
           if (psleep = options[:poll_sleep_amount]) && !psleep.nil?
             c.poll_sleep_amount = Float(psleep)
           end
@@ -73,6 +76,7 @@ module Resque
           c.verbose = !!options[:verbose] if options.key?(:verbose)
         end
       end
+      # rubocop:enable Metrics/AbcSize
 
       def cleanup_pid_file
         return unless pidfile_path

--- a/lib/resque/scheduler/lock/base.rb
+++ b/lib/resque/scheduler/lock/base.rb
@@ -11,7 +11,7 @@ module Resque
           @key = key
 
           # 3 minute default timeout
-          @timeout = options[:timeout] || 60 * 3
+          @timeout = options[:timeout] || Resque::Scheduler.lock_timeout
         end
 
         # Attempts to acquire the lock. Returns true if successfully acquired.

--- a/test/configuration_test.rb
+++ b/test/configuration_test.rb
@@ -19,6 +19,12 @@ context 'Configuration' do
     end
   end
 
+  test 'setting lock_timeout from environment' do
+    configuration.environment = { 'LOCK_TIMEOUT' => '47' }
+
+    assert_equal 47, configuration.lock_timeout
+  end
+
   test 'env set from Rails.env' do
     Rails.expects(:env).returns('development')
 


### PR DESCRIPTION
Expose the `timeout` configuration option used in `Resque::Scheduler::Locking::Base`

Related issue: https://github.com/resque/resque-scheduler/issues/700