### PR TITLE
Fix undef `header` method CI failures

### DIFF
--- a/test/resque-web_test.rb
+++ b/test/resque-web_test.rb
@@ -307,7 +307,7 @@ context 'on POST to /delayed/cancel_now' do
   test 'redirects to overview' do
     post '/delayed/cancel_now'
     assert last_response.status == 302
-    assert last_response.header['Location'].include? '/delayed'
+    assert last_response.location.include? '/delayed'
   end
 end
 
@@ -316,7 +316,7 @@ context 'on POST to /delayed/clear' do
 
   test 'redirects to delayed' do
     assert last_response.status == 302
-    assert last_response.header['Location'].include? '/delayed'
+    assert last_response.location.include? '/delayed'
   end
 end
 


### PR DESCRIPTION
[example failure](https://github.com/resque/resque-scheduler/actions/runs/11523448976/job/32081502082?pr=794)
```
  NoMethodError: undefined method `header' for #<Rack::MockResponse:0x00005611e9cbc950>
  Did you mean?  headers
```

`#header` was [dropped in the Rack 3.1 release](https://github.com/rack/rack/blob/main/CHANGELOG.md#removed-1), while the `#location` helper has been around since 2.x (https://github.com/rack/rack/commit/5e0b0a32be000a090e1580e19d9729e9b1b8ca69)