### PR TITLE
Fix `Resque::Scheduler.print_schedule`

### DIFF
--- a/lib/resque/scheduler.rb
+++ b/lib/resque/scheduler.rb
@@ -86,8 +86,8 @@ module Resque
         if rufus_scheduler
           log! "Scheduling Info\tLast Run"
           scheduler_jobs = rufus_scheduler.jobs
-          scheduler_jobs.each do |_k, v|
-            log! "#{v.t}\t#{v.last}\t"
+          scheduler_jobs.each do |job|
+            log! "#{job.opts}\t#{job.last_time}\t"
           end
         end
       end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -589,15 +589,15 @@ context 'Resque::Scheduler' do
 
   context 'printing schedule' do
     setup do
-      Resque::Scheduler.expects(:log!).at_least_once
+      Resque::Scheduler.stubs(:log!)
     end
 
     test 'prints schedule' do
-      fake_rufus_scheduler = mock
-      fake_rufus_scheduler.expects(:jobs).at_least_once
-                          .returns(foo: OpenStruct.new(t: nil, last: nil))
-      Resque::Scheduler.expects(:rufus_scheduler).at_least_once
-                       .returns(fake_rufus_scheduler)
+      rufus_scheduler = Rufus::Scheduler.new
+      fake_job = rufus_scheduler.at(Time.now + 1, job: true) {}
+      Resque::Scheduler.expects(:rufus_scheduler).at_least_once.returns(rufus_scheduler)
+      Resque::Scheduler.expects(:log!).with("#{fake_job.opts}\t#{fake_job.last_time}\t")
+
       Resque::Scheduler.print_schedule
     end
   end


### PR DESCRIPTION
Added in https://github.com/resque/resque-scheduler/commit/893f13cfde48b1634faef8a870b134e8e9757661, this is intended to help with debugging. The `:t` and `:last` attrs were removed in the [`rufus-scheduler` 2.0 -> 3.0 update ](https://github.com/jmettraux/rufus-scheduler/compare/v2.0.24...v3.0.0)

It seems `#print_schedule` likely hasn't worked since the `rufus-scheduler` depenency was bumped to require ~3.0 in https://github.com/resque/resque-scheduler/commit/d24657e2b2babeb660ebfceb2d78b0e755199c33 - and could possibly be removed instead (considering the amount of time since then without a report).

This fixes the `OpenStruct` warnings seen in tests for newer Ruby versions ([example failure](https://github.com/resque/resque-scheduler/actions/runs/11523361257/job/32081248023?pr=793) - ~coupled with https://github.com/resque/resque-scheduler/pull/793 this should get CI back to 🟢 [see all tests passing with both changes here](https://github.com/codealchemy/resque-scheduler/commits/refs/heads/fix-ci-throwaway/?since=2024-10-25&until=2024-10-25)~)