### PR TITLE
Remove circular require for resque from resque-scheduler

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -1,5 +1,4 @@
 # vim:fileencoding=utf-8
-require 'resque'
 require_relative 'plugin'
 require_relative '../scheduler'
 


### PR DESCRIPTION
This resolves the following warning:

```
BUNDLE_GEMFILE=test/gemfiles/Gemfile-rails-main bundle exec rake test:activejob
/home/zzak/.rbenv/versions/3.3.5/bin/ruby -w -I"lib:test:lib:test/active_job" /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader
.rb "test/active_job/cases/adapter_test.rb"
Using resque
/home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75: warning: loading in progress
, circular require considered harmful - /home/zzak/code/resque/lib/active_job/queue_adapters/resque_adapter.rb
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in  `<main>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:6:in  `select'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/gems/rake-13.2.1/lib/rake/rake_test_loader.rb:21:in  `block in <main>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque/test/active_job/cases/adapter_test.rb:3:in  `<top (required)>'
        from /home/zzak/code/resque/test/active_job/cases/adapter_test.rb:3:in  `require_relative'
        from /home/zzak/code/resque/test/active_job/helper.rb:15:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque/test/active_job/adapters/resque.rb:3:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:61:in  `on_load'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:61:in  `each'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:62:in  `block in on_loa
d'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:92:in  `execute_hook'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:87:in  `with_execution_
control'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:97:in  `block in execut
e_hook'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/gems/3.3.0/bundler/gems/rails-9de4972adee8/activesupport/lib/active_support/lazy_load_hooks.rb:97:in  `class_eval'
        from /home/zzak/code/resque/test/active_job/adapters/resque.rb:4:in  `block in <top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque/lib/active_job/queue_adapters/resque_adapter.rb:7:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque-scheduler/lib/resque-scheduler.rb:4:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque-scheduler/lib/resque/scheduler/extension.rb:4:in  `<top (required)>'
        from /home/zzak/code/resque-scheduler/lib/resque/scheduler/extension.rb:4:in  `require_relative'
        from /home/zzak/code/resque-scheduler/lib/resque/scheduler/delaying_extensions.rb:2:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'
        from /home/zzak/code/resque/lib/resque.rb:27:in  `<top (required)>'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `block (2 levels) in replace_require'
        from /home/zzak/.rbenv/versions/3.3.5/lib/ruby/3.3.0/bundled_gems.rb:75:in  `require'

Run options: --seed 11193

  # Running:

.

Finished in 0.002215s, 451.5588 runs/s, 451.5588 assertions/s.

1 runs, 1 assertions, 0 failures, 0 errors, 0 skips
```