### PR TITLE
Add Ruby 3.3 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -27,6 +27,7 @@ jobs:
           - "3.0"
           - 3.1
           - 3.2
+          - 3.3
         resque-version:
           - "master"
           - "~> 2.4.0"


### PR DESCRIPTION
This PR adds Ruby 3.3 to the CI matrix.