### PR TITLE
Version 4.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,22 @@
 
 **ATTN**: This project uses [semantic versioning](http://semver.org/).
 
+## [4.10.3] - 2024-12-30
+### Added
+* Expose timeout for lock via environment variable configuration by @pmm4654 in #786
+* Add Ruby 3.3 to the CI matrix by @santiagorodriguez96 in #797
+
+### Fixed
+* Fix schedule hooks when enqueuing configured job by @codealchemy in #792
+* Fix undefined `header` method CI failures by @codealchemy in #793
+
+### Documentation
+* Fix typo by @dijonkitchen in #789
+* Fix links to generated docs by @dijonkitchen in #790
+
+### Security
+* Bump github/codeql-action from 2 to 3 by @dependabot in #785
+
 ## [4.10.2] - 2023-12-15
 ### Fixed
 * Finish fixing CVE-2022-44303, XSS in delayed_schedules by @PatrickTulskie in #783

--- a/lib/resque/scheduler/version.rb
+++ b/lib/resque/scheduler/version.rb
@@ -2,6 +2,6 @@
 
 module Resque
   module Scheduler
-    VERSION = '4.10.2'.freeze
+    VERSION = '4.11.0'.freeze
   end
 end


### PR DESCRIPTION
This pull request includes updates to the `CHANGELOG.md` and version bump in the `lib/resque/scheduler/version.rb` file. The most important changes are summarized below:

### Changelog updates:

* Expose timeout for lock via environment variable configuration.
* Add Ruby 3.3 to the CI matrix.
* Fix schedule hooks when enqueuing configured job.
* Fix undefined `header` method CI failures.
* Fix typo and links to generated docs.
* Bump github/codeql-action from 2 to 3.

### Version update:

* Update version from `4.10.2` to `4.11.0` in `lib/resque/scheduler/version.rb`.