### PR TITLE
Require rack < 3

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -45,6 +45,8 @@ jobs:
             rufus-scheduler: 3.2
           - ruby-version: 3.2
             rufus-scheduler: 3.2
+          - ruby-version: 3.3
+            rufus-scheduler: 3.2
 
           - ruby-version: 2.3
             resque-version: "~> 1.27"

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -48,6 +48,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'rack', '< 3'
   spec.add_development_dependency 'rack-test'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'simplecov'


### PR DESCRIPTION
As resque doesn't support rack >=3 and as it doesn't specify its required versions correctly, this PR is needed to make resque-scheduler's CI green