### PR TITLE
Add Ruby 3.4 to the CI matrix

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -28,6 +28,7 @@ jobs:
           - 3.1
           - 3.2
           - 3.3
+          - 3.4
         resque-version:
           - "master"
           - "~> 2.4.0"
@@ -46,6 +47,8 @@ jobs:
           - ruby-version: 3.2
             rufus-scheduler: 3.2
           - ruby-version: 3.3
+            rufus-scheduler: 3.2
+          - ruby-version: 3.4
             rufus-scheduler: 3.2
 
           - ruby-version: 2.3

--- a/resque-scheduler.gemspec
+++ b/resque-scheduler.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'json'
   spec.add_development_dependency 'minitest'
   spec.add_development_dependency 'mocha'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'pry'
   spec.add_development_dependency 'rack', '< 3'
   spec.add_development_dependency 'rack-test'
@@ -60,6 +61,7 @@ Gem::Specification.new do |spec|
   # positives for new contributors, which is not a nice experience.
   spec.add_development_dependency 'rubocop', '~> 0.40.0'
 
+  spec.add_runtime_dependency 'logger'
   spec.add_runtime_dependency 'mono_logger', '~> 1.0'
   spec.add_runtime_dependency 'redis', '>= 3.3'
   spec.add_runtime_dependency 'resque', '>= 1.27'


### PR DESCRIPTION
This PR adds Ruby 3.4 to the CI matrix.