### PR TITLE
Fix double invocation of schedule hooks for delayed jobs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/MethodLength:
 # Offense count: 2
 # Configuration parameters: CountComments.
 Metrics/ModuleLength:
-  Max: 364
+  Max: 375
 
 # Offense count: 1
 Style/CaseEquality:

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -56,6 +56,7 @@ Resque Scheduler authors
 - Nickolas Means
 - Olek Janiszewski
 - Olivier Brisse
+- Paul Wille
 - Petteri Räty
 - Phil Cohen
 - Rob Olson

--- a/README.md
+++ b/README.md
@@ -502,12 +502,13 @@ A future version of resque-scheduler may do this for you.
 Similar to the `before_enqueue`- and `after_enqueue`-hooks provided in Resque
 (>= 1.19.1), your jobs can specify one or more of the following hooks:
 
-* `before_schedule`: Called with the job args before a job is placed on
-  the delayed queue. If the hook returns `false`, the job will not be placed on
-  the queue.
-* `after_schedule`: Called with the job args after a job is placed on the
-  delayed queue. Any exception raised propagates up to the code with queued the
-  job.
+* `before_schedule`: Called with the job args before a job is scheduled. This
+  includes delayed jobs (when placed on the delayed queue via `enqueue_at`/`enqueue_in`)
+  and recurring cron jobs (each time the job is enqueued).
+  If the hook returns `false`, the job will not be enqueued.
+* `after_schedule`: Called with the job args after a job is scheduled (same
+  scenarios as `before_schedule`). Any exception raised propagates up to the
+  calling code.
 * `before_delayed_enqueue`: Called with the job args after the job has been
   removed from the delayed queue, but not yet put on a normal queue. It is
   called before `before_enqueue`-hooks, and on the same job instance as the

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -17,21 +17,22 @@ context 'scheduling jobs with hooks' do
     Resque.redis.lrange("queue:#{SomeRealClass.queue}", 0, -1).map(&JSON.method(:parse))
   end
 
-  test 'before_schedule and after_scheduler hooks are called when enqueued from config' do
-    SomeRealClass.expects(:before_schedule_example).with('/tmp')
-    SomeRealClass.expects(:after_schedule_example).with('/tmp')
+  test 'direct enqueue does not trigger schedule hooks' do
+    SomeRealClass.expects(:before_schedule_example).never
+    SomeRealClass.expects(:after_schedule_example).never
     Resque::Scheduler.enqueue(config)
 
     assert_equal [{ 'class' => 'SomeRealClass', 'args' => ['/tmp'] }], enqueued
   end
 
-  test 'any before_schedule returning false will halt the job from being enqueued' do
-    SomeRealClass.expects(:before_schedule_a).with('/tmp').returns(false)
-    SomeRealClass.expects(:before_schedule_b).with('/tmp')
+  test 'direct enqueue bypasses before_schedule hooks so job cannot be halted' do
+    SomeRealClass.expects(:before_schedule_a).never
+    SomeRealClass.expects(:before_schedule_b).never
     SomeRealClass.expects(:after_schedule_example).never
     Resque::Scheduler.enqueue(config)
 
-    assert_equal [], enqueued
+    # Job is enqueued because schedule hooks are not run for direct enqueue
+    assert_equal [{ 'class' => 'SomeRealClass', 'args' => ['/tmp'] }], enqueued
   end
 
   test 'before_schedule hook that does not return false should be enqueued' do
@@ -69,5 +70,80 @@ context 'scheduling jobs with hooks' do
 
       Resque::Scheduler.enqueue(config)
     end
+  end
+end
+
+context 'delayed job hooks' do
+  setup do
+    Resque::Scheduler.quiet = true
+    Resque.data_store.redis.flushall
+  end
+
+  test 'schedule hooks are not called again when delayed job is transferred to queue' do
+    future_time = Time.now + 600
+
+    # Hooks should be called when the job is initially scheduled
+    SomeRealClass.expects(:before_schedule_example).with('foo')
+    SomeRealClass.expects(:after_schedule_example).with('foo')
+    Resque.enqueue_at(future_time, SomeRealClass, 'foo')
+
+    # When the job is transferred from delayed queue to actual queue,
+    # schedule hooks should NOT be called again
+    SomeRealClass.expects(:before_schedule_example).never
+    SomeRealClass.expects(:after_schedule_example).never
+    Resque::Scheduler.handle_delayed_items(future_time)
+  end
+
+  test 'before_delayed_enqueue is called when delayed job is transferred to queue' do
+    future_time = Time.now + 600
+
+    # Schedule the job (schedule hooks called here)
+    SomeRealClass.stubs(:before_schedule_example)
+    SomeRealClass.stubs(:after_schedule_example)
+    Resque.enqueue_at(future_time, SomeRealClass, 'foo')
+
+    # before_delayed_enqueue should be called when transferring to actual queue
+    # Note: args come back as strings after JSON serialization
+    SomeRealClass.expects(:before_delayed_enqueue_example).with('foo').once
+
+    Resque::Scheduler.handle_delayed_items(future_time)
+  end
+end
+
+context 'cron job hooks' do
+  def config
+    {
+      'cron' => '* * * * *',
+      'class' => 'SomeRealClass',
+      'args' => '/tmp'
+    }
+  end
+
+  def enqueued
+    Resque.redis.lrange("queue:#{SomeRealClass.queue}", 0, -1).map(&JSON.method(:parse))
+  end
+
+  setup do
+    Resque::Scheduler.quiet = true
+    Resque.data_store.redis.flushall
+    Resque::Scheduler.stubs(:am_master).returns(true)
+  end
+
+  test 'cron job triggers schedule hooks via enqueue_recurring' do
+    SomeRealClass.expects(:before_schedule_example).with('/tmp')
+    SomeRealClass.expects(:after_schedule_example).with('/tmp')
+
+    Resque::Scheduler.send(:enqueue_recurring, 'some_job', config)
+
+    assert_equal [{ 'class' => 'SomeRealClass', 'args' => ['/tmp'] }], enqueued
+  end
+
+  test 'cron job before_schedule returning false halts the job' do
+    SomeRealClass.expects(:before_schedule_example).with('/tmp').returns(false)
+    SomeRealClass.expects(:after_schedule_example).never
+
+    Resque::Scheduler.send(:enqueue_recurring, 'some_job', config)
+
+    assert_equal [], enqueued
   end
 end

--- a/test/scheduler_test.rb
+++ b/test/scheduler_test.rb
@@ -29,7 +29,7 @@ context 'Resque::Scheduler' do
     Resque::Scheduler.enqueue_from_config(config)
   end
 
-  test 'enqueue_from_config runs before_delayed_enqueue and resque hooks but not schedule hooks' do
+  test 'enqueue_from_config runs before_delayed_enqueue and resque hooks not schedule hooks' do
     Resque::Scheduler.env = 'production'
     config = {
       'cron' => '* * * * *',


### PR DESCRIPTION
Fixes [#810](https://github.com/resque/resque-scheduler/issues/810)

  ## Summary
  - Move invoking schedule hooks from `enqueue_from_config` to `enqueue_recurring`
  - This ensures hooks are called for cron jobs but not again when delayed jobs are transferred to the work queue
  - Extract `extract_klass_and_params` helper to avoid duplication
  - Update README to clarify when hooks are called