### PR TITLE
Fix flaky test by using strings instead of symbols for JSON-serialized args

### DIFF
--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -36,7 +36,6 @@ context 'scheduling jobs with hooks' do
 
   test 'before_schedule hook that does not return false should be enqueued' do
     enqueue_time = Time.now + 1
-    # Use string 'foo' since JSON serialization converts symbols to strings
     SomeRealClass.expects(:before_schedule_example).with('foo')
     SomeRealClass.expects(:after_schedule_example).with('foo')
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, 'foo')
@@ -46,7 +45,6 @@ context 'scheduling jobs with hooks' do
 
   test 'before_schedule hook that returns false should not be enqueued' do
     enqueue_time = Time.now + 1
-    # Use string 'foo' since JSON serialization converts symbols to strings
     SomeRealClass.expects(:before_schedule_example).with('foo').returns(false)
     SomeRealClass.expects(:after_schedule_example).never
     Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, 'foo')

--- a/test/scheduler_hooks_test.rb
+++ b/test/scheduler_hooks_test.rb
@@ -36,18 +36,20 @@ context 'scheduling jobs with hooks' do
 
   test 'before_schedule hook that does not return false should be enqueued' do
     enqueue_time = Time.now + 1
-    SomeRealClass.expects(:before_schedule_example).with(:foo)
-    SomeRealClass.expects(:after_schedule_example).with(:foo)
-    Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)
+    # Use string 'foo' since JSON serialization converts symbols to strings
+    SomeRealClass.expects(:before_schedule_example).with('foo')
+    SomeRealClass.expects(:after_schedule_example).with('foo')
+    Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, 'foo')
     assert_equal(1, Resque.delayed_timestamp_size(enqueue_time.to_i),
                  'job should be enqueued')
   end
 
   test 'before_schedule hook that returns false should not be enqueued' do
     enqueue_time = Time.now + 1
-    SomeRealClass.expects(:before_schedule_example).with(:foo).returns(false)
+    # Use string 'foo' since JSON serialization converts symbols to strings
+    SomeRealClass.expects(:before_schedule_example).with('foo').returns(false)
     SomeRealClass.expects(:after_schedule_example).never
-    Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, :foo)
+    Resque.enqueue_at(enqueue_time.to_i, SomeRealClass, 'foo')
     assert_equal(0, Resque.delayed_timestamp_size(enqueue_time.to_i),
                  'job should not be enqueued')
   end


### PR DESCRIPTION
Fixes a flaky test on Ruby 2.4 where mocha expectations fail due to symbol/string mismatch.