### PR TITLE
Pipeline count_all_scheduled_jobs for significantly faster execution

### DIFF
--- a/lib/resque/scheduler/delaying_extensions.rb
+++ b/lib/resque/scheduler/delaying_extensions.rb
@@ -261,12 +261,18 @@ module Resque
         count
       end
 
+      # Counts all jobs across all delayed timestamps.
+      # Uses pipelined LLEN calls in batches to avoid blocking the Redis thread
+      # for too long while being significantly faster than sequential calls.
       def count_all_scheduled_jobs
-        total_jobs = 0
-        Array(redis.zrange(:delayed_queue_schedule, 0, -1)).each do |ts|
-          total_jobs += redis.llen("delayed:#{ts}").to_i
+        timestamps = Array(redis.zrange(:delayed_queue_schedule, 0, -1))
+        return 0 if timestamps.empty?
+
+        timestamps.each_slice(10_000).sum do |batch|
+          redis.pipelined do |pipeline|
+            batch.each { |ts| pipeline.llen("delayed:#{ts}") }
+          end.sum
         end
-        total_jobs
       end
 
       # Discover if a job has been delayed.

--- a/test/delayed_queue_test.rb
+++ b/test/delayed_queue_test.rb
@@ -1100,6 +1100,10 @@ context 'DelayedQueue' do
     end
   end
 
+  test 'count_all_scheduled_jobs returns 0 when no jobs are scheduled' do
+    assert_equal(0, Resque.count_all_scheduled_jobs)
+  end
+
   test 'delayed?' do
     Resque.enqueue_at Time.now + 1, SomeIvarJob
     Resque.enqueue_at Time.now + 1, SomeIvarJob, id: 1


### PR DESCRIPTION
## Problem

`count_all_scheduled_jobs` issues one sequential `LLEN` Redis call per delayed timestamp. With many delayed jobs, this becomes a significant bottleneck, especially when called from metric collectors like [yabeda-resque](https://github.com/jbockler/yabeda-resque) during Prometheus scrapes.

On our production system (20k timestamps, 36k delayed jobs) this single method took **5.6 seconds**, causing Prometheus scrape timeouts. For the same number of jobs and timestamps, the pipelined implementation took only **~300ms**. 

  | | Jobs | Timestamps | Duration |
  |---|---|---|---|
  | Sequential (before) | 35,948 | 20,309 | 5,641ms |
  | Pipelined (after) | 35,969 | 20,309 | 304ms |

  **18.6x faster.**

## Solution

Pipeline all `LLEN` calls in batches of 10,000 to avoid blocking the Redis thread for too long while still being significantly faster than sequential calls.

## Production benchmarks
We have run this implementation in production by inclduing it in https://github.com/jbockler/yabeda-resque first [See PR](https://github.com/jbockler/yabeda-resque/pull/1), so I am confident this works in practice. We have seen a reduction of query times by an order of magnitide confirming our simple measerement above. 
